### PR TITLE
fix: ensure Celery Beat reloads schedule from code on startup

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -113,7 +113,7 @@ services:
     image: ghcr.io/${GITHUB_REPO:-splagemann/strava-garmin-bridge}/backend:${IMAGE_TAG:-latest}
     container_name: strava-garmin-celery-beat
     restart: unless-stopped
-    command: celery -A app.celery_app beat --loglevel=info
+    command: sh -c "rm -f /app/celerybeat-schedule* && celery -A app.celery_app beat --loglevel=info"
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
   # Celery Beat (for scheduled tasks)
   celery-beat:
     build: .
-    command: celery -A app.celery_app beat --loglevel=info
+    command: sh -c "rm -f /app/celerybeat-schedule* && celery -A app.celery_app beat --loglevel=info"
     volumes:
       - .:/app
     environment:


### PR DESCRIPTION
## Summary

- Modified celery-beat command in both `docker-compose.yml` and `docker-compose.prod.yml` to automatically clean the persistent schedule file on startup
- Ensures new scheduled tasks are always picked up from code configuration rather than being blocked by stale schedule files

## Problem

Celery Beat persists its schedule in a local file (`celerybeat-schedule`). When new scheduled tasks are added to the code (like the `poll_garmin_activities_task` for Garmin → Strava sync), the old schedule file prevents these new tasks from being picked up, causing only the Strava → Garmin sync to run in production.

## Solution

The celery-beat containers now execute `rm -f /app/celerybeat-schedule*` before starting Celery Beat, ensuring a fresh schedule is loaded from the code configuration on every restart.

## Changes

- **docker-compose.prod.yml**: Updated celery-beat command
- **docker-compose.yml**: Updated celery-beat command

## Test Plan

- [ ] Deploy to production
- [ ] Restart celery-beat container
- [ ] Verify both scheduled tasks appear in logs:
  - `poll-strava-activities-every-5-minutes`
  - `poll-garmin-activities-every-5-minutes`
- [ ] Confirm Garmin → Strava sync executes every 5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)