### PR TITLE
fix: preserve entrypoint in celery-beat to ensure migrations run

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -113,7 +113,8 @@ services:
     image: ghcr.io/${GITHUB_REPO:-splagemann/strava-garmin-bridge}/backend:${IMAGE_TAG:-latest}
     container_name: strava-garmin-celery-beat
     restart: unless-stopped
-    command: sh -c "rm -f /app/celerybeat-schedule* && celery -A app.celery_app beat --loglevel=info"
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["rm -f /app/celerybeat-schedule* && /docker-entrypoint.sh celery -A app.celery_app beat --loglevel=info"]
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,8 @@ services:
   # Celery Beat (for scheduled tasks)
   celery-beat:
     build: .
-    command: sh -c "rm -f /app/celerybeat-schedule* && celery -A app.celery_app beat --loglevel=info"
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["rm -f /app/celerybeat-schedule* && /docker-entrypoint.sh celery -A app.celery_app beat --loglevel=info"]
     volumes:
       - .:/app
     environment:


### PR DESCRIPTION
## Summary

- Fixed celery-beat container configuration to properly preserve the Docker entrypoint
- Ensures database migrations run before Celery Beat starts
- Resolves "Can't locate revision" error in production

## Problem

PR #2 introduced a fix to clean the celerybeat-schedule file, but it inadvertently bypassed the Docker entrypoint script by using:
```yaml
command: sh -c "rm -f /app/celerybeat-schedule* && celery -A app.celery_app beat --loglevel=info"
```

This prevented the `/docker-entrypoint.sh` script from running, which is responsible for:
1. Waiting for the database to be ready
2. Running `alembic upgrade head` to apply migrations

Without migrations running, when Celery Beat tried to import the app configuration, it failed with:
```
ERROR [alembic.util.messaging] Can't locate revision identified by 'b5f902b08422'
```

## Solution

Properly chain the schedule cleanup with the entrypoint script:
```yaml
entrypoint: ["/bin/sh", "-c"]
command: ["rm -f /app/celerybeat-schedule* && /docker-entrypoint.sh celery -A app.celery_app beat --loglevel=info"]
```

This ensures the execution flow is:
1. Clean old schedule file ✓
2. Run entrypoint (which runs migrations) ✓
3. Start Celery Beat ✓

## Changes

- **docker-compose.prod.yml**: Updated celery-beat to preserve entrypoint
- **docker-compose.yml**: Updated celery-beat to preserve entrypoint

## Test Plan

- [ ] Deploy to production
- [ ] Verify celery-beat container starts without migration errors
- [ ] Check logs show migrations running: `docker logs strava-garmin-celery-beat`
- [ ] Confirm both scheduled tasks execute properly:
  - `poll-strava-activities-every-5-minutes`
  - `poll-garmin-activities-every-5-minutes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)