### PR TITLE
fix: remove unnecessary celery_beat_data volume

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -143,8 +143,6 @@ services:
       ENVIRONMENT: production
     networks:
       - strava-garmin-network
-    volumes:
-      - celery_beat_data:/app
 
   frontend:
     image: ghcr.io/${GITHUB_REPO:-splagemann/strava-garmin-bridge}/frontend:${IMAGE_TAG:-latest}
@@ -169,8 +167,6 @@ volumes:
   postgres_data:
     driver: local
   redis_data:
-    driver: local
-  celery_beat_data:
     driver: local
 
 networks:


### PR DESCRIPTION
## Summary

- Removed `celery_beat_data` volume from celery-beat container in production
- Ensures schedule cleanup on startup works as intended
- Aligns production config with development environment

## Problem

The `celery_beat_data:/app` volume mount was:

1. **Contradicting our schedule reload fix**: We explicitly delete `celerybeat-schedule*` files on startup to force fresh schedule loading, but the volume persists these files anyway, making the fix ineffective.

2. **Mounting over /app directory**: This mounts a persistent volume over the entire `/app` directory, which could potentially override the application code from the Docker image with stale files from previous deployments.

3. **Not needed**: Celery Beat doesn't need persistent storage because:
   - The schedule is defined in code (`app/celery_app.py`)
   - Task execution state is stored in Redis (our broker/backend)
   - We intentionally want to reload the schedule from code on every startup

## Solution

Remove the volume mount entirely. This ensures:
- The schedule file is properly cleaned on startup ✓
- Fresh application code from the Docker image is used ✓
- New scheduled tasks are always picked up from code ✓
- Consistency with dev environment configuration ✓

## Changes

- **docker-compose.prod.yml**: 
  - Removed `volumes` section from celery-beat service
  - Removed `celery_beat_data` from volumes definition

## Test Plan

- [ ] Deploy to production
- [ ] Verify celery-beat starts successfully without volume
- [ ] Confirm schedule is loaded fresh from code
- [ ] Check both scheduled tasks run properly:
  - `poll-strava-activities-every-5-minutes`
  - `poll-garmin-activities-every-5-minutes`

## Note

After deploying, the old `celery_beat_data` volume can be manually removed with:
```bash
docker volume rm strava-garmin-bridge_celery_beat_data
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)