### PR TITLE
fix: add CODECOV_TOKEN to Codecov uploads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,9 +75,11 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           flags: backend
           name: backend-coverage
+          fail_ci_if_error: false
 
   frontend-tests:
     name: Frontend Tests
@@ -113,9 +115,11 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./frontend/coverage/coverage-final.json
           flags: frontend
           name: frontend-coverage
+          fail_ci_if_error: false
 
   # integration-tests:
   #   name: Integration Tests


### PR DESCRIPTION
## Summary
Adds the CODECOV_TOKEN secret to Codecov upload actions to fix coverage uploads for protected branches.

## Changes
- Add `token: ${{ secrets.CODECOV_TOKEN }}` to backend Codecov upload
- Add `token: ${{ secrets.CODECOV_TOKEN }}` to frontend Codecov upload
- Set `fail_ci_if_error: false` to prevent CI failures if Codecov is unavailable

## Issue
Currently, Codecov uploads are failing with:
```
error - Branch `main` is protected but no token was provided
error - Commit creating failed: {"message":"Token required because branch is protected"}
```

## Next Steps
After merging this PR, you need to add the `CODECOV_TOKEN` secret to the repository:
1. Go to https://codecov.io and get your repository token
2. Add it to GitHub secrets: Settings → Secrets and variables → Actions → New repository secret
3. Name: `CODECOV_TOKEN`
4. Value: [your Codecov token]

## Test Plan
- ✅ Workflow file syntax is valid
- Coverage uploads will succeed once CODECOV_TOKEN secret is added