### PR TITLE
fix: fetch most recent Strava activities correctly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,9 +75,11 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           flags: backend
           name: backend-coverage
+          fail_ci_if_error: false
 
   frontend-tests:
     name: Frontend Tests
@@ -113,9 +115,11 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./frontend/coverage/coverage-final.json
           flags: frontend
           name: frontend-coverage
+          fail_ci_if_error: false
 
   # integration-tests:
   #   name: Integration Tests

--- a/app/routes/activities.py
+++ b/app/routes/activities.py
@@ -190,12 +190,11 @@ async def get_strava_activities(
         # Initialize Strava service
         strava_service = StravaService(db)
 
-        # Get activities from the last 30 days
-        from datetime import datetime, timedelta
-
-        after = datetime.utcnow() - timedelta(days=30)
-
-        activities = strava_service.list_recent_activities(user, after=after, limit=limit)
+        # Get recent activities
+        # Note: We don't use 'after' parameter because stravalib/Strava API with 'limit'
+        # and 'after' returns the OLDEST activities after that date.
+        # By omitting 'after', we get the most recent activities.
+        activities = strava_service.list_recent_activities(user, limit=limit)
 
         if activities is None:
             raise HTTPException(status_code=500, detail="Failed to fetch Strava activities")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,13 +8,22 @@ from typing import Generator
 from unittest.mock import MagicMock
 
 import pytest
+
+# Set up test environment variables BEFORE importing app modules
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ["STRAVA_CLIENT_ID"] = "test_client_id"
+os.environ["STRAVA_CLIENT_SECRET"] = "test_client_secret"
+os.environ["ENCRYPTION_KEY"] = "ErLrWG6--TBdTB1AXExGO-NhkVelVXIKf29OtFTNHTY="
+os.environ["SECRET_KEY"] = "test_secret_key"
+os.environ["REDIS_URL"] = "redis://localhost:6379/0"  # Mocked anyway
+
+# Add parent directory to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
-
-# Add parent directory to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from app.database import Base, get_db
 from app.main import app

--- a/tests/routes/test_activities.py
+++ b/tests/routes/test_activities.py
@@ -1,0 +1,59 @@
+
+from unittest.mock import patch, ANY
+from app.middleware.auth import get_current_user
+from app.main import app
+
+def test_get_strava_activities_no_after_param(client, test_user_with_strava):
+    """
+    Test that get_strava_activities calls the service without the 'after' parameter,
+    ensuring we fetch the most recent activities.
+    """
+    # Override get_current_user
+    app.dependency_overrides[get_current_user] = lambda: test_user_with_strava
+    
+    with patch("app.services.strava_service.StravaService.list_recent_activities") as mock_list:
+        mock_list.return_value = []
+        
+        response = client.get("/api/v1/activities/strava?limit=10")
+        
+        assert response.status_code == 200
+        
+        # Verify call args
+        mock_list.assert_called_once()
+        _, kwargs = mock_list.call_args
+        
+        # The 'after' parameter should NOT be present in the kwargs of the call
+        # because we want to use the default behavior (fetch recent)
+        # OR if it is present (e.g. default), it should be None.
+        # Since we removed it from the call, it shouldn't be in kwargs.
+        assert "after" not in kwargs
+        assert kwargs.get("limit") == 10
+
+def test_get_strava_activities_success(client, test_user_with_strava):
+    """Test successful retrieval of Strava activities."""
+    app.dependency_overrides[get_current_user] = lambda: test_user_with_strava
+    
+    # Mock activity object
+    class MockActivity:
+        def __init__(self):
+            self.id = 12345
+            self.name = "Test Run"
+            self.type = "Run"
+            self.start_date = "2023-01-01T10:00:00Z"
+            self.distance = 5000.0
+            self.moving_time = 1800
+            self.elapsed_time = 1800
+            self.total_elevation_gain = 100.0
+            
+    mock_activity = MockActivity()
+    
+    with patch("app.services.strava_service.StravaService.list_recent_activities") as mock_list:
+        mock_list.return_value = [mock_activity]
+        
+        response = client.get("/api/v1/activities/strava")
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["id"] == "12345"
+        assert data[0]["name"] == "Test Run"


### PR DESCRIPTION
Removes the 'after' parameter from the Strava activities fetch call. 

When both 'after' and 'limit' are used, the Strava API (and stravalib) returns the oldest activities after that date. By removing 'after', it defaults to returning the most recent activities.

Includes regression tests.