### PR TITLE
feat: add Profile & Settings pages, Garmin 2FA, no-GPS handling, Sync…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,20 @@ jobs:
       #     isort --check-only backend/app/
       #     flake8 backend/app/ --max-line-length=100 --ignore=E203,W503
 
+      - name: Run database migrations
+        run: |
+          cd backend
+          alembic upgrade head
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
+          REDIS_URL: redis://localhost:6379/0
+          SECRET_KEY: test-secret-key-for-ci
+          ENCRYPTION_KEY: BP67TC-RR8iT2t0ubohSl3S_N_QBOCB1wm3kQysAJdY=
+          STRAVA_CLIENT_ID: test-client-id
+          STRAVA_CLIENT_SECRET: test-client-secret
+          BASE_URL: http://localhost:8000
+          FRONTEND_URL: http://localhost:5173
+
       - name: Run tests with coverage
         run: |
           cd backend

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+coverage/
 
 # Environments
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -98,5 +98,9 @@ docker-compose.override.yml
 tmp/
 temp/
 
+# Cache and uploads
+backend/data/cache/
+backend/data/uploads/
+
 # Pre-commit
 .pre-commit-config.yaml.bak

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,8 +207,11 @@ decrypted = decrypt_password(encrypted)
 
 ## Important Constraints
 
+### Garmin library
+The `garminconnect` package is from PyPI (`garminconnect==0.2.38`). See [python-garminconnect](https://github.com/cyberjunky/python-garminconnect).
+
 ### File Naming Conflicts
-**Never** create a file named `garminconnect.py` in the project root - it conflicts with the installed `garminconnect` package and causes import errors. The actual library source is in `../garminconnect.py` for reference only.
+**Never** create a file named `garminconnect.py` in the project root - it conflicts with the installed `garminconnect` package and causes import errors.
 
 ### OAuth State Management
 The OAuth flow uses JWT-signed state tokens for CSRF protection. The frontend stores these in both sessionStorage (primary) and localStorage (fallback) to handle browser redirect issues. Backend validates state tokens with direct comparison fallback for resilience.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ For production deployment using pre-built Docker images from GitHub Container Re
 
 1. **Clone the repository**
 ```bash
+git clone <repo-url>
 cd strava-garmin-bridge
 ```
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,8 +24,10 @@ COPY . .
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
-# Create non-root user
-RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /backend
+# Create non-root user and persistent token directory
+RUN useradd -m -u 1000 appuser \
+    && mkdir -p /backend/data/garmin_tokens \
+    && chown -R appuser:appuser /backend
 USER appuser
 
 # Expose port

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -2,6 +2,7 @@
 Celery application configuration.
 """
 
+from celery.schedules import crontab
 from datetime import timedelta
 
 from celery import Celery
@@ -29,6 +30,12 @@ _beat_schedule = {
     "poll-withings-weight-every-30-minutes": {
         "task": "app.tasks.sync_tasks.poll_withings_weight_task",
         "schedule": timedelta(minutes=30),
+    },
+    "apply-workout-schedules-daily": {
+        "task": "app.tasks.sync_tasks.apply_workout_schedules_task",
+        # Run at 06:00 UTC every day — early enough that workouts are on the calendar
+        # before most users start their day.
+        "schedule": crontab(hour=6, minute=0),
     },
 }
 if settings.GARMIN_TO_STRAVA_SYNC_ENABLED:

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -16,6 +16,31 @@ celery_app = Celery(
     include=["app.tasks.sync_tasks"],
 )
 
+# Build beat schedule: Garmin → Strava poll only when enabled
+_beat_schedule = {
+    "poll-strava-activities-every-5-minutes": {
+        "task": "app.tasks.sync_tasks.poll_strava_activities_task",
+        "schedule": timedelta(minutes=5),
+        "kwargs": {
+            "lookback_days": 7,
+            "max_activities_per_user": 100,
+        },
+    },
+    "poll-withings-weight-every-30-minutes": {
+        "task": "app.tasks.sync_tasks.poll_withings_weight_task",
+        "schedule": timedelta(minutes=30),
+    },
+}
+if settings.GARMIN_TO_STRAVA_SYNC_ENABLED:
+    _beat_schedule["poll-garmin-activities-every-5-minutes"] = {
+        "task": "app.tasks.sync_tasks.poll_garmin_activities_task",
+        "schedule": timedelta(minutes=5),
+        "kwargs": {
+            "lookback_days": 7,
+            "max_activities_per_user": 100,
+        },
+    }
+
 # Configure Celery
 celery_app.conf.update(
     task_serializer="json",
@@ -28,26 +53,5 @@ celery_app.conf.update(
     task_soft_time_limit=240,  # 4 minutes soft limit
     worker_prefetch_multiplier=1,
     worker_max_tasks_per_child=100,
-    beat_schedule={
-        "poll-strava-activities-every-5-minutes": {
-            "task": "app.tasks.sync_tasks.poll_strava_activities_task",
-            "schedule": timedelta(minutes=5),
-            "kwargs": {
-                "lookback_days": 7,  # fetch activities from last 7 days
-                "max_activities_per_user": 100,  # increased to handle more activities
-            },
-        },
-        "poll-garmin-activities-every-5-minutes": {
-            "task": "app.tasks.sync_tasks.poll_garmin_activities_task",
-            "schedule": timedelta(minutes=5),
-            "kwargs": {
-                "lookback_days": 7,  # fetch activities from last 7 days
-                "max_activities_per_user": 100,
-            },
-        },
-        "poll-withings-weight-every-30-minutes": {
-            "task": "app.tasks.sync_tasks.poll_withings_weight_task",
-            "schedule": timedelta(minutes=30),
-        },
-    },
+    beat_schedule=_beat_schedule,
 )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -7,7 +7,6 @@ from functools import lru_cache
 from pydantic import ConfigDict
 from pydantic_settings import BaseSettings
 
-
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
 
@@ -38,14 +37,18 @@ class Settings(BaseSettings):
     # API Configuration
     API_V1_PREFIX: str = "/api/v1"
 
-    model_config = ConfigDict(env_file=".env", case_sensitive=True)
+    # Sync direction: when False, only Strava → Garmin runs (no Garmin → Strava)
+    GARMIN_TO_STRAVA_SYNC_ENABLED: bool = False
 
+    # When False, skip activities without GPS in both directions (Strava→Garmin and Garmin→Strava). User can override in Settings.
+    ALLOW_EXPORT_WITHOUT_GPS: bool = False
+
+    model_config = ConfigDict(env_file=".env", case_sensitive=True)
 
 @lru_cache()
 def get_settings() -> Settings:
     """Get cached settings instance."""
     return Settings()
-
 
 # Create a global settings instance
 settings = get_settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -72,7 +72,7 @@ async def health_check():
 
 
 # Import and include routers
-from app.routes import activities, auth, filters, sync
+from app.routes import activities, auth, filters, sync, workouts
 
 app.include_router(auth.router, prefix=f"{settings.API_V1_PREFIX}/auth", tags=["Authentication"])
 app.include_router(filters.router, prefix=f"{settings.API_V1_PREFIX}/filters", tags=["Filters"])
@@ -80,7 +80,7 @@ app.include_router(sync.router, prefix=f"{settings.API_V1_PREFIX}/sync", tags=["
 app.include_router(
     activities.router, prefix=f"{settings.API_V1_PREFIX}/activities", tags=["Activities"]
 )
-
+app.include_router(workouts.router, prefix=f"{settings.API_V1_PREFIX}/workouts", tags=["Workouts"])
 
 if __name__ == "__main__":
     import uvicorn

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -49,7 +49,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins,  # Specific origins only
     allow_credentials=True,  # Allow cookies/auth headers
-    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],  # Explicit methods
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],  # Explicit methods
     allow_headers=["Content-Type", "Authorization"],  # Explicit headers
     max_age=600,  # Cache preflight requests for 10 minutes
 )

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,9 +4,11 @@ Database models.
 
 from app.models.auth import GarminAuth, StravaAuth, WithingsAuth
 from app.models.filter import ActivityFilter
+from app.models.scheduled_workout_instance import ScheduledWorkoutInstance
 from app.models.sync_log import SyncLog
 from app.models.user import User
 from app.models.user_settings import UserSettings
+from app.models.workout_schedule import WorkoutSchedule
 
 __all__ = [
     "User",
@@ -16,4 +18,6 @@ __all__ = [
     "WithingsAuth",
     "ActivityFilter",
     "SyncLog",
+    "WorkoutSchedule",
+    "ScheduledWorkoutInstance",
 ]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,9 +6,11 @@ from app.models.auth import GarminAuth, StravaAuth, WithingsAuth
 from app.models.filter import ActivityFilter
 from app.models.sync_log import SyncLog
 from app.models.user import User
+from app.models.user_settings import UserSettings
 
 __all__ = [
     "User",
+    "UserSettings",
     "StravaAuth",
     "GarminAuth",
     "WithingsAuth",

--- a/backend/app/models/scheduled_workout_instance.py
+++ b/backend/app/models/scheduled_workout_instance.py
@@ -1,0 +1,39 @@
+"""
+ScheduledWorkoutInstance — tracks individual (user, workout, date) pushes to Garmin
+so that re-running a sync never creates duplicates.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+
+class ScheduledWorkoutInstance(Base):
+    """One scheduled workout on one specific date for one user."""
+
+    __tablename__ = "scheduled_workout_instances"
+    __table_args__ = (
+        # Prevent scheduling the same workout on the same date twice
+        UniqueConstraint("user_id", "workout_id", "scheduled_date", name="uq_user_workout_date"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    # Garmin workout ID (string to be safe with large IDs)
+    workout_id = Column(String, nullable=False)
+    # ISO date string YYYY-MM-DD
+    scheduled_date = Column(String, nullable=False, index=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User")
+
+    def __repr__(self) -> str:
+        return (
+            f"<ScheduledWorkoutInstance(user={self.user_id}, "
+            f"workout={self.workout_id}, date={self.scheduled_date})>"
+        )

--- a/backend/app/models/sync_log.py
+++ b/backend/app/models/sync_log.py
@@ -43,7 +43,11 @@ class SyncLog(Base):
 
     # Debug data (for troubleshooting)
     strava_data = Column(JSON, nullable=True)  # Raw Strava activity object
-    gpx_data = Column(Text, nullable=True)  # GPX data sent to Garmin
+    garmin_data = Column(Text, nullable=True)  # File summary or Garmin response data
+
+    # Stored file data (for download feature)
+    uploaded_file_path = Column(String(255), nullable=True)  # Path to file on filesystem
+    uploaded_file_extension = Column(String(10), nullable=True)  # File extension: "fit", "gpx", "tcx", etc.
 
     # Timestamps
     created_at = Column(DateTime, default=datetime.utcnow, index=True)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -17,6 +17,9 @@ class User(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     email = Column(String, unique=True, index=True, nullable=False)
+    username = Column(String(64), unique=True, index=True, nullable=True)
+    first_name = Column(String(255), nullable=True)
+    last_name = Column(String(255), nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
     is_active = Column(Boolean, default=True)
@@ -27,6 +30,7 @@ class User(Base):
     withings_auth = relationship("WithingsAuth", back_populates="user", uselist=False)
     activity_filters = relationship("ActivityFilter", back_populates="user")
     sync_logs = relationship("SyncLog", back_populates="user")
+    user_settings = relationship("UserSettings", back_populates="user", cascade="all, delete-orphan")
 
     def __repr__(self):
         return f"<User(id={self.id}, email={self.email})>"

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -30,7 +30,12 @@ class User(Base):
     withings_auth = relationship("WithingsAuth", back_populates="user", uselist=False)
     activity_filters = relationship("ActivityFilter", back_populates="user")
     sync_logs = relationship("SyncLog", back_populates="user")
-    user_settings = relationship("UserSettings", back_populates="user", cascade="all, delete-orphan")
+    user_settings = relationship(
+        "UserSettings", back_populates="user", cascade="all, delete-orphan"
+    )
+    workout_schedules = relationship(
+        "WorkoutSchedule", back_populates="user", cascade="all, delete-orphan"
+    )
 
     def __repr__(self):
         return f"<User(id={self.id}, email={self.email})>"

--- a/backend/app/models/user_settings.py
+++ b/backend/app/models/user_settings.py
@@ -1,0 +1,28 @@
+"""
+User settings model (key-value store for per-user preferences).
+"""
+
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+
+class UserSettings(Base):
+    """Per-user settings as key-value (one row per user per key). Value stored as string."""
+
+    __tablename__ = "user_settings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    key = Column(String(128), nullable=False, index=True)
+    value = Column(String(512), nullable=False)
+
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    __table_args__ = (UniqueConstraint("user_id", "key", name="uq_user_settings_user_key"),)
+
+    user = relationship("User", back_populates="user_settings")

--- a/backend/app/models/workout_schedule.py
+++ b/backend/app/models/workout_schedule.py
@@ -1,0 +1,36 @@
+"""
+WorkoutSchedule model — recurring Garmin workout assignments.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, JSON, String
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+
+class WorkoutSchedule(Base):
+    """Recurring weekly schedule that pushes a Garmin workout on chosen days."""
+
+    __tablename__ = "workout_schedules"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    workout_id = Column(String, nullable=False)
+    workout_name = Column(String, nullable=False)
+    # List of ints using Python weekday() convention: 0=Mon … 6=Sun
+    days_of_week = Column(JSON, nullable=False)
+    is_active = Column(Boolean, default=True, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    user = relationship("User", back_populates="workout_schedules")
+
+    def __repr__(self) -> str:
+        return (
+            f"<WorkoutSchedule(id={self.id}, user_id={self.user_id}, "
+            f"workout='{self.workout_name}', days={self.days_of_week})>"
+        )

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -2,6 +2,6 @@
 API routes.
 """
 
-from app.routes import activities, auth, filters, sync
+from app.routes import activities, auth, filters, sync, workouts
 
-__all__ = ["auth", "filters", "sync", "activities"]
+__all__ = ["auth", "filters", "sync", "activities", "workouts"]

--- a/backend/app/routes/activities.py
+++ b/backend/app/routes/activities.py
@@ -42,25 +42,25 @@ def _get_cache_file_path(user_id: int, limit: int) -> Path:
 
 def _load_cache(user_id: int, limit: int) -> Optional[Tuple[List[Dict], datetime]]:
     """Load cached activities from file if not expired.
-    
+
     Returns:
         Tuple of (list of activity dicts, cache timestamp) or None if expired/missing
     """
     cache_file = _get_cache_file_path(user_id, limit)
-    
+
     if not cache_file.exists():
         return None
-    
+
     try:
         # Check file modification time
         file_mtime = datetime.fromtimestamp(cache_file.stat().st_mtime)
         age = (datetime.utcnow() - file_mtime).total_seconds()
-        
+
         if age >= CACHE_TTL_SECONDS:
             # Cache expired, delete file
             cache_file.unlink()
             return None
-        
+
         # Load cached data
         with open(cache_file, "r") as f:
             data = json.load(f)
@@ -69,7 +69,7 @@ def _load_cache(user_id: int, limit: int) -> Optional[Tuple[List[Dict], datetime
             for activity in activities:
                 if "start_date" in activity and isinstance(activity["start_date"], str):
                     activity["start_date"] = datetime.fromisoformat(activity["start_date"])
-            
+
             return activities, file_mtime
     except Exception as e:
         logger.warning(f"Failed to load cache file {cache_file}: {e}")
@@ -84,7 +84,7 @@ def _load_cache(user_id: int, limit: int) -> Optional[Tuple[List[Dict], datetime
 def _save_cache(user_id: int, limit: int, activities: List):
     """Save activities to cache file."""
     cache_file = _get_cache_file_path(user_id, limit)
-    
+
     try:
         # Convert datetime objects to ISO strings for JSON serialization
         serializable_activities = []
@@ -93,12 +93,12 @@ def _save_cache(user_id: int, limit: int, activities: List):
             if "start_date" in activity_dict and isinstance(activity_dict["start_date"], datetime):
                 activity_dict["start_date"] = activity_dict["start_date"].isoformat()
             serializable_activities.append(activity_dict)
-        
+
         data = {
             "activities": serializable_activities,
             "cached_at": datetime.utcnow().isoformat(),
         }
-        
+
         with open(cache_file, "w") as f:
             json.dump(data, f, default=str)
     except Exception as e:
@@ -110,21 +110,21 @@ def _cleanup_expired_cache():
     cache_dir = _get_cache_directory()
     if not cache_dir.exists():
         return
-    
+
     now = datetime.utcnow()
     cleaned = 0
-    
+
     for cache_file in cache_dir.glob("strava_activities_*.json"):
         try:
             file_mtime = datetime.fromtimestamp(cache_file.stat().st_mtime)
             age = (now - file_mtime).total_seconds()
-            
+
             if age >= CACHE_TTL_SECONDS:
                 cache_file.unlink()
                 cleaned += 1
         except Exception as e:
             logger.debug(f"Error checking cache file {cache_file}: {e}")
-    
+
     if cleaned > 0:
         logger.debug(f"Cleaned up {cleaned} expired cache files")
 
@@ -134,17 +134,17 @@ def _invalidate_user_cache(user_id: int):
     cache_dir = _get_cache_directory()
     if not cache_dir.exists():
         return
-    
+
     pattern = f"strava_activities_u{user_id}_*.json"
     removed = 0
-    
+
     for cache_file in cache_dir.glob(pattern):
         try:
             cache_file.unlink()
             removed += 1
         except Exception as e:
             logger.warning(f"Failed to remove cache file {cache_file}: {e}")
-    
+
     if removed > 0:
         logger.info(f"Invalidated cache for user {user_id} ({removed} files)")
 
@@ -188,7 +188,10 @@ async def get_garmin_activities(
         # Initialize Garmin service and connect
         garmin_service = GarminService(db)
         if not garmin_service.connect(user):
-            raise HTTPException(status_code=500, detail="Failed to connect to Garmin")
+            logger.warning(
+                f"Could not connect to Garmin for user {user.id} — returning empty activity list"
+            )
+            return []
 
         # Get activities from the last 30 days
         from datetime import datetime, timedelta
@@ -319,15 +322,16 @@ async def get_strava_activities(
 
     # Cleanup expired cache entries periodically (every ~10th request)
     import random
+
     if random.random() < 0.1:  # 10% chance to cleanup
         _cleanup_expired_cache()
-    
+
     # Check cache first
     cached_result = _load_cache(user.id, limit)
     if cached_result:
         cached_activities_dicts, cache_timestamp = cached_result
         age = (datetime.utcnow() - cache_timestamp).total_seconds()
-        
+
         logger.info(
             f"Returning cached Strava activities for user {user.id} "
             f"(age: {age:.1f}s, limit: {limit})"
@@ -435,11 +439,11 @@ async def get_strava_activities(
             )
 
         logger.info(f"Returning {len(result)} Strava activities for user {user.id}")
-        
+
         # Cache the result to file
         _save_cache(user.id, limit, result)
         logger.debug(f"Cached Strava activities for user {user.id}, limit: {limit}")
-        
+
         return result
 
     except HTTPException:

--- a/backend/app/routes/activities.py
+++ b/backend/app/routes/activities.py
@@ -2,9 +2,12 @@
 Activity listing routes for Garmin and Strava.
 """
 
+import json
 import logging
-from datetime import datetime
-from typing import List, Optional
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict
@@ -18,6 +21,132 @@ from app.services.strava_service import StravaService
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+CACHE_TTL_SECONDS = 300  # 5 minutes
+CACHE_DIR_NAME = "data/cache"
+
+
+def _get_cache_directory() -> Path:
+    """Get cache directory path, creating it if needed."""
+    backend_root = Path(__file__).parent.parent.parent
+    cache_dir = backend_root / CACHE_DIR_NAME
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir
+
+
+def _get_cache_file_path(user_id: int, limit: int) -> Path:
+    """Get cache file path for a user and limit."""
+    cache_dir = _get_cache_directory()
+    return cache_dir / f"strava_activities_u{user_id}_l{limit}.json"
+
+
+def _load_cache(user_id: int, limit: int) -> Optional[Tuple[List[Dict], datetime]]:
+    """Load cached activities from file if not expired.
+    
+    Returns:
+        Tuple of (list of activity dicts, cache timestamp) or None if expired/missing
+    """
+    cache_file = _get_cache_file_path(user_id, limit)
+    
+    if not cache_file.exists():
+        return None
+    
+    try:
+        # Check file modification time
+        file_mtime = datetime.fromtimestamp(cache_file.stat().st_mtime)
+        age = (datetime.utcnow() - file_mtime).total_seconds()
+        
+        if age >= CACHE_TTL_SECONDS:
+            # Cache expired, delete file
+            cache_file.unlink()
+            return None
+        
+        # Load cached data
+        with open(cache_file, "r") as f:
+            data = json.load(f)
+            activities = data.get("activities", [])
+            # Convert datetime strings back to datetime objects
+            for activity in activities:
+                if "start_date" in activity and isinstance(activity["start_date"], str):
+                    activity["start_date"] = datetime.fromisoformat(activity["start_date"])
+            
+            return activities, file_mtime
+    except Exception as e:
+        logger.warning(f"Failed to load cache file {cache_file}: {e}")
+        # Delete corrupted cache file
+        try:
+            cache_file.unlink()
+        except Exception:
+            pass
+        return None
+
+
+def _save_cache(user_id: int, limit: int, activities: List):
+    """Save activities to cache file."""
+    cache_file = _get_cache_file_path(user_id, limit)
+    
+    try:
+        # Convert datetime objects to ISO strings for JSON serialization
+        serializable_activities = []
+        for activity in activities:
+            activity_dict = activity.dict() if hasattr(activity, "dict") else dict(activity)
+            if "start_date" in activity_dict and isinstance(activity_dict["start_date"], datetime):
+                activity_dict["start_date"] = activity_dict["start_date"].isoformat()
+            serializable_activities.append(activity_dict)
+        
+        data = {
+            "activities": serializable_activities,
+            "cached_at": datetime.utcnow().isoformat(),
+        }
+        
+        with open(cache_file, "w") as f:
+            json.dump(data, f, default=str)
+    except Exception as e:
+        logger.warning(f"Failed to save cache file {cache_file}: {e}")
+
+
+def _cleanup_expired_cache():
+    """Remove expired cache files."""
+    cache_dir = _get_cache_directory()
+    if not cache_dir.exists():
+        return
+    
+    now = datetime.utcnow()
+    cleaned = 0
+    
+    for cache_file in cache_dir.glob("strava_activities_*.json"):
+        try:
+            file_mtime = datetime.fromtimestamp(cache_file.stat().st_mtime)
+            age = (now - file_mtime).total_seconds()
+            
+            if age >= CACHE_TTL_SECONDS:
+                cache_file.unlink()
+                cleaned += 1
+        except Exception as e:
+            logger.debug(f"Error checking cache file {cache_file}: {e}")
+    
+    if cleaned > 0:
+        logger.debug(f"Cleaned up {cleaned} expired cache files")
+
+
+def _invalidate_user_cache(user_id: int):
+    """Invalidate all cache entries for a specific user."""
+    cache_dir = _get_cache_directory()
+    if not cache_dir.exists():
+        return
+    
+    pattern = f"strava_activities_u{user_id}_*.json"
+    removed = 0
+    
+    for cache_file in cache_dir.glob(pattern):
+        try:
+            cache_file.unlink()
+            removed += 1
+        except Exception as e:
+            logger.warning(f"Failed to remove cache file {cache_file}: {e}")
+    
+    if removed > 0:
+        logger.info(f"Invalidated cache for user {user_id} ({removed} files)")
 
 
 class ActivityResponse(BaseModel):
@@ -179,6 +308,8 @@ async def get_strava_activities(
     Get recent activities from Strava.
 
     Requires: Bearer token authentication
+
+    Cached for 5 minutes to reduce Strava API calls.
     """
     user = current_user
 
@@ -186,14 +317,33 @@ async def get_strava_activities(
     if not user.strava_auth:
         raise HTTPException(status_code=400, detail="Strava not connected")
 
+    # Cleanup expired cache entries periodically (every ~10th request)
+    import random
+    if random.random() < 0.1:  # 10% chance to cleanup
+        _cleanup_expired_cache()
+    
+    # Check cache first
+    cached_result = _load_cache(user.id, limit)
+    if cached_result:
+        cached_activities_dicts, cache_timestamp = cached_result
+        age = (datetime.utcnow() - cache_timestamp).total_seconds()
+        
+        logger.info(
+            f"Returning cached Strava activities for user {user.id} "
+            f"(age: {age:.1f}s, limit: {limit})"
+        )
+        # Convert dicts back to ActivityResponse objects
+        return [ActivityResponse(**activity) for activity in cached_activities_dicts]
+
     try:
         # Initialize Strava service
         strava_service = StravaService(db)
 
-        # Get recent activities
+        # Get recent activities from Strava API
         # Note: We don't use 'after' parameter because stravalib/Strava API with 'limit'
         # and 'after' returns the OLDEST activities after that date.
         # By omitting 'after', we get the most recent activities.
+        logger.info(f"Fetching Strava activities from API for user {user.id}, limit: {limit}")
         activities = strava_service.list_recent_activities(user, limit=limit)
 
         if activities is None:
@@ -285,6 +435,11 @@ async def get_strava_activities(
             )
 
         logger.info(f"Returning {len(result)} Strava activities for user {user.id}")
+        
+        # Cache the result to file
+        _save_cache(user.id, limit, result)
+        logger.debug(f"Cached Strava activities for user {user.id}, limit: {limit}")
+        
         return result
 
     except HTTPException:

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -3,6 +3,7 @@ Authentication routes for Strava OAuth and Garmin credentials.
 """
 
 import logging
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import RedirectResponse
@@ -11,6 +12,14 @@ from sqlalchemy.orm import Session
 
 from app.config import settings
 from app.database import get_db
+from app.utils.user_settings import (
+    KEY_ALLOW_EXPORT_WITHOUT_GPS,
+    KEY_GARMIN_TO_STRAVA_SYNC_DISABLED,
+    get_allow_export_without_gps,
+    get_garmin_to_strava_sync_enabled,
+    get_setting_override_bool,
+    set_setting,
+)
 from app.middleware.auth import get_current_user
 from app.models import User
 from app.services.garmin_service import GarminService
@@ -27,6 +36,29 @@ class GarminCredentials(BaseModel):
 
     email: str
     password: str
+
+
+class GarminMFAVerify(BaseModel):
+    """Request model for Garmin MFA code verification."""
+
+    mfa_token: str
+    mfa_code: str
+
+
+class SettingsUpdate(BaseModel):
+    """Request model for user settings update."""
+
+    garmin_to_strava_sync_disabled: Optional[bool] = None  # None = use server default (True = sync off)
+    allow_export_without_gps: Optional[bool] = None  # None = use server default
+
+
+class ProfileUpdate(BaseModel):
+    """Request model for profile update (email, username, first_name, last_name)."""
+
+    email: Optional[str] = None
+    username: Optional[str] = None
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
 
 
 class WithingsAuthRequest(BaseModel):
@@ -156,50 +188,65 @@ async def save_garmin_credentials(
 ):
     """
     Save Garmin Connect credentials for authenticated user.
-    Credentials are encrypted before storage and verified before saving.
+    Supports MFA: if the account has 2FA/MFA enabled, the response will include
+    mfa_required and mfa_token; submit the MFA code to POST /auth/garmin/mfa.
 
     Requires: Bearer token authentication
-
-    Note: Credentials must be valid. If you have 2FA/MFA enabled on Garmin,
-    you may need to use an app-specific password or ensure you complete
-    the authentication flow properly.
     """
     user = current_user
-
-    # Initialize Garmin service
     garmin_service = GarminService(db)
 
-    # Verify credentials first
-    logger.info(f"Verifying Garmin credentials for user {user.id}")
-    is_valid, error_message = garmin_service.verify_credentials(
-        credentials.email, credentials.password
-    )
-
-    if not is_valid:
-        detail = (
-            f"Invalid Garmin credentials: {error_message}"
-            if error_message
-            else "Invalid Garmin credentials"
+    try:
+        result, data = garmin_service.start_login_with_mfa(
+            user.id, credentials.email, credentials.password
         )
-        logger.error(f"Failed to verify Garmin credentials for user {user.id}: {detail}")
-
-        # Provide helpful message if it's likely 2FA
-        if "AssertionError" in detail or "2FA" in detail or "MFA" in detail:
-            detail += "\n\nNote: If you have 2FA/MFA enabled on your Garmin account, you may need to use an app-specific password or ensure proper authentication flow."
-
+    except Exception as e:
+        detail = str(e) if str(e) else "Invalid Garmin credentials"
+        logger.error(f"Garmin login failed for user {user.id}: {e}", exc_info=True)
         raise HTTPException(status_code=401, detail=detail)
 
-    logger.info(f"Garmin credentials verified successfully for user {user.id}")
+    if result == "mfa_required":
+        return {
+            "message": "MFA code required",
+            "mfa_required": True,
+            "mfa_token": data,
+        }
 
-    # Save credentials
+    # Login succeeded without MFA; save credentials and session
+    garmin_client = data
     try:
-        garmin_auth = garmin_service.save_credentials(user, credentials.email, credentials.password)
-
-        return {"message": "Garmin credentials verified and saved successfully"}
-
+        garmin_auth = garmin_service.save_credentials(
+            user, credentials.email, credentials.password
+        )
+        garmin_auth.session_data = garmin_client.garth.dumps()
+        db.commit()
     except Exception as e:
         logger.error(f"Error saving Garmin credentials: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to save credentials")
+
+    return {
+        "message": "Garmin credentials verified and saved successfully",
+        "mfa_required": False,
+    }
+
+
+@router.post("/garmin/mfa")
+async def verify_garmin_mfa(
+    body: GarminMFAVerify,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Complete Garmin login with MFA code (after POST /auth/garmin/credentials
+    returned mfa_required and mfa_token).
+    """
+    garmin_service = GarminService(db)
+    success, error_message = garmin_service.complete_mfa(
+        body.mfa_token, body.mfa_code, current_user
+    )
+    if not success:
+        raise HTTPException(status_code=400, detail=error_message)
+    return {"message": "Garmin credentials verified and saved successfully"}
 
 
 @router.get("/withings/auth-url")
@@ -247,7 +294,10 @@ async def exchange_withings_code(
 
 
 @router.get("/status")
-async def auth_status(current_user: User = Depends(get_current_user)):
+async def auth_status(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
     """
     Check authentication status for Strava, Garmin, and Withings for the authenticated user.
 
@@ -255,10 +305,103 @@ async def auth_status(current_user: User = Depends(get_current_user)):
     """
     return {
         "email": current_user.email,
+        "username": current_user.username,
+        "first_name": current_user.first_name,
+        "last_name": current_user.last_name,
         "strava_connected": current_user.strava_auth is not None,
         "garmin_connected": current_user.garmin_auth is not None,
         "withings_connected": current_user.withings_auth is not None,
         "strava_athlete_id": (
             current_user.strava_auth.athlete_id if current_user.strava_auth else None
         ),
+        "garmin_to_strava_sync_disabled": not get_garmin_to_strava_sync_enabled(current_user, db),
     }
+
+
+@router.patch("/profile")
+async def update_profile(
+    body: ProfileUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Update current user profile (email, username, first_name, last_name)."""
+    user = db.query(User).filter(User.id == current_user.id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    if body.email is not None:
+        existing = db.query(User).filter(User.email == body.email, User.id != user.id).first()
+        if existing:
+            raise HTTPException(status_code=400, detail="Email already in use")
+        user.email = body.email.strip()
+    if body.username is not None:
+        val = body.username.strip() or None
+        if val:
+            existing = db.query(User).filter(User.username == val, User.id != user.id).first()
+            if existing:
+                raise HTTPException(status_code=400, detail="Username already in use")
+        user.username = val
+    if body.first_name is not None:
+        user.first_name = body.first_name.strip() or None
+    if body.last_name is not None:
+        user.last_name = body.last_name.strip() or None
+    db.commit()
+    db.refresh(user)
+    return {
+        "email": user.email,
+        "username": user.username,
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+    }
+
+
+@router.get("/settings")
+async def get_settings(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Get current user settings (for Settings tab).
+    Returns effective values and user overrides (null = using server default).
+    """
+    enabled = get_garmin_to_strava_sync_enabled(current_user, db)
+    return {
+        "garmin_to_strava_sync_disabled": not enabled,
+        "garmin_to_strava_sync_disabled_override": get_setting_override_bool(db, current_user.id, KEY_GARMIN_TO_STRAVA_SYNC_DISABLED),
+        "allow_export_without_gps": get_allow_export_without_gps(current_user, db),
+        "allow_export_without_gps_override": get_setting_override_bool(db, current_user.id, KEY_ALLOW_EXPORT_WITHOUT_GPS),
+    }
+
+
+@router.patch("/settings")
+async def update_settings(
+    body: SettingsUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Update current user settings."""
+    try:
+        user = db.query(User).filter(User.id == current_user.id).first()
+        if not user:
+            raise HTTPException(status_code=404, detail="User not found")
+        if body.garmin_to_strava_sync_disabled is not None:
+            set_setting(db, user.id, KEY_GARMIN_TO_STRAVA_SYNC_DISABLED, "true" if body.garmin_to_strava_sync_disabled else "false")
+        if body.allow_export_without_gps is not None:
+            set_setting(db, user.id, KEY_ALLOW_EXPORT_WITHOUT_GPS, "true" if body.allow_export_without_gps else "false")
+        db.commit()
+        enabled = get_garmin_to_strava_sync_enabled(user, db)
+        return {
+            "garmin_to_strava_sync_disabled": not enabled,
+            "garmin_to_strava_sync_disabled_override": get_setting_override_bool(db, user.id, KEY_GARMIN_TO_STRAVA_SYNC_DISABLED),
+            "allow_export_without_gps": get_allow_export_without_gps(user, db),
+            "allow_export_without_gps_override": get_setting_override_bool(db, user.id, KEY_ALLOW_EXPORT_WITHOUT_GPS),
+        }
+    except HTTPException:
+        db.rollback()
+        raise
+    except Exception as e:
+        db.rollback()
+        logger.exception("Failed to update user settings")
+        msg = str(e)
+        if "garmin_to_strava_sync" in msg or "allow_export_without_gps" in msg or "does not exist" in msg or "column" in msg.lower():
+            msg = "Database schema may be outdated. Run: alembic upgrade head"
+        raise HTTPException(status_code=500, detail=msg)

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -30,8 +30,9 @@ from app.utils.user_settings import (
     set_setting,
 )
 from app.middleware.auth import get_current_user
-from app.models import User
+from app.models import StravaAuth, User
 from app.services.garmin_service import GarminService
+from garminconnect import GarminConnectTooManyRequestsError
 from app.services.strava_service import StravaService
 from app.services.withings_service import WithingsService
 from app.utils.jwt import create_access_token, verify_state_token
@@ -178,12 +179,21 @@ async def exchange_strava_code(auth_request: StravaAuthRequest, db: Session = De
             athlete_email = f"athlete_{athlete_id}@strava.local"
             logger.info(f"No email provided by Strava, using placeholder: {athlete_email}")
 
-        user = db.query(User).filter(User.email == athlete_email).first()
-        if not user:
-            user = User(email=athlete_email)
-            db.add(user)
-            db.commit()
-            db.refresh(user)
+        # Look up by athlete_id first — this handles reconnects and prevents the
+        # UniqueViolation that occurs when athlete_id already exists for another user row.
+        existing_auth = (
+            db.query(StravaAuth).filter(StravaAuth.athlete_id == str(athlete_id)).first()
+        )
+        if existing_auth:
+            user = existing_auth.user
+            logger.info(f"Returning user {user.id} matched by athlete_id {athlete_id}")
+        else:
+            user = db.query(User).filter(User.email == athlete_email).first()
+            if not user:
+                user = User(email=athlete_email)
+                db.add(user)
+                db.commit()
+                db.refresh(user)
 
         # Save Strava auth with athlete info
         strava_auth = strava_service.save_auth(user, token_response, athlete)
@@ -225,10 +235,16 @@ async def save_garmin_credentials(
         result, data = garmin_service.start_login_with_mfa(
             user.id, credentials.email, credentials.password
         )
+    except GarminConnectTooManyRequestsError:
+        raise HTTPException(
+            status_code=429,
+            detail="Garmin is rate-limiting login attempts. Please wait a few minutes before trying again.",
+        )
     except Exception as e:
         detail = str(e) if str(e) else "Invalid Garmin credentials"
         logger.error(f"Garmin login failed for user {user.id}: {e}", exc_info=True)
-        raise HTTPException(status_code=401, detail=detail)
+        # Use 400, not 401 — a 401 would trigger the frontend's global logout interceptor
+        raise HTTPException(status_code=400, detail=detail)
 
     if result == "mfa_required":
         return {
@@ -237,12 +253,11 @@ async def save_garmin_credentials(
             "mfa_token": data,
         }
 
-    # Login succeeded without MFA; save credentials and session
+    # Login succeeded without MFA; save credentials and session (disk + DB)
     garmin_client = data
     try:
         garmin_auth = garmin_service.save_credentials(user, credentials.email, credentials.password)
-        garmin_auth.session_data = garmin_client.garth.dumps()
-        db.commit()
+        garmin_service._persist_tokens(garmin_client, garmin_auth)
     except Exception as e:
         logger.error(f"Error saving Garmin credentials: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to save credentials")

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -14,10 +14,19 @@ from app.config import settings
 from app.database import get_db
 from app.utils.user_settings import (
     KEY_ALLOW_EXPORT_WITHOUT_GPS,
+    KEY_DISPLAY_TIME_FORMAT,
+    KEY_DISPLAY_TIMEZONE,
     KEY_GARMIN_TO_STRAVA_SYNC_DISABLED,
+    KEY_SYNC_SCHEDULE_MINUTES,
+    SYNC_SCHEDULE_CHOICES,
     get_allow_export_without_gps,
+    get_display_time_format,
+    get_display_timezone,
+    get_fit_device_settings,
     get_garmin_to_strava_sync_enabled,
     get_setting_override_bool,
+    get_sync_schedule_minutes,
+    set_fit_device_settings,
     set_setting,
 )
 from app.middleware.auth import get_current_user
@@ -45,20 +54,36 @@ class GarminMFAVerify(BaseModel):
     mfa_code: str
 
 
+class FitDeviceSettingsBody(BaseModel):
+    """FIT device settings (user-level): written into FIT files on export."""
+
+    device_name: Optional[str] = None
+    serial_number: Optional[str] = None
+    manufacturer_id: Optional[str] = None
+    software_version: Optional[str] = None
+    product_id: Optional[str] = None
+
+
 class SettingsUpdate(BaseModel):
     """Request model for user settings update."""
 
-    garmin_to_strava_sync_disabled: Optional[bool] = None  # None = use server default (True = sync off)
+    garmin_to_strava_sync_disabled: Optional[bool] = (
+        None  # None = use server default (True = sync off)
+    )
     allow_export_without_gps: Optional[bool] = None  # None = use server default
+    sync_schedule_minutes: Optional[int] = None  # One of 5, 10, 15, 30, 45, 60, 120, 240; default 5
+    fit_device_settings: Optional[FitDeviceSettingsBody] = None
 
 
 class ProfileUpdate(BaseModel):
-    """Request model for profile update (email, username, first_name, last_name)."""
+    """Request model for profile update (email, username, first_name, last_name, display_timezone, display_time_format)."""
 
     email: Optional[str] = None
     username: Optional[str] = None
     first_name: Optional[str] = None
     last_name: Optional[str] = None
+    display_timezone: Optional[str] = None
+    display_time_format: Optional[str] = None  # "12h" or "24h"
 
 
 class WithingsAuthRequest(BaseModel):
@@ -215,9 +240,7 @@ async def save_garmin_credentials(
     # Login succeeded without MFA; save credentials and session
     garmin_client = data
     try:
-        garmin_auth = garmin_service.save_credentials(
-            user, credentials.email, credentials.password
-        )
+        garmin_auth = garmin_service.save_credentials(user, credentials.email, credentials.password)
         garmin_auth.session_data = garmin_client.garth.dumps()
         db.commit()
     except Exception as e:
@@ -259,7 +282,7 @@ async def get_withings_auth_url():
         logger.info(f"Generating Withings auth URL with redirect_uri: {redirect_uri}")
 
         auth_url, state = WithingsService.get_authorization_url(redirect_uri)
-        
+
         return {"auth_url": auth_url, "state": state}
     except Exception as e:
         logger.error(f"Error generating Withings auth URL: {e}", exc_info=True)
@@ -270,7 +293,7 @@ async def get_withings_auth_url():
 async def exchange_withings_code(
     auth_request: WithingsAuthRequest,
     current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
 ):
     """
     Exchange Withings authorization code for access token.
@@ -278,15 +301,15 @@ async def exchange_withings_code(
     try:
         # Verify state
         if not verify_state_token(auth_request.signed_state, auth_request.state):
-             raise HTTPException(status_code=400, detail="Invalid state token")
+            raise HTTPException(status_code=400, detail="Invalid state token")
 
         withings_service = WithingsService(db)
         redirect_uri = f"{settings.FRONTEND_URL}/auth/withings/callback"
-        
+
         token_response = withings_service.exchange_code_for_token(auth_request.code, redirect_uri)
-        
+
         withings_service.save_auth(current_user, token_response)
-        
+
         return {"message": "Withings connected successfully"}
     except Exception as e:
         logger.error(f"Error exchanging Withings code: {e}", exc_info=True)
@@ -308,6 +331,8 @@ async def auth_status(
         "username": current_user.username,
         "first_name": current_user.first_name,
         "last_name": current_user.last_name,
+        "display_timezone": get_display_timezone(db, current_user.id),
+        "display_time_format": get_display_time_format(db, current_user.id),
         "strava_connected": current_user.strava_auth is not None,
         "garmin_connected": current_user.garmin_auth is not None,
         "withings_connected": current_user.withings_auth is not None,
@@ -344,6 +369,13 @@ async def update_profile(
         user.first_name = body.first_name.strip() or None
     if body.last_name is not None:
         user.last_name = body.last_name.strip() or None
+    if body.display_timezone is not None:
+        tz = (body.display_timezone or "").strip() or "UTC"
+        set_setting(db, user.id, KEY_DISPLAY_TIMEZONE, tz[:64])
+    if body.display_time_format is not None:
+        fmt = (body.display_time_format or "").strip().lower()
+        if fmt in ("12h", "24h"):
+            set_setting(db, user.id, KEY_DISPLAY_TIME_FORMAT, fmt)
     db.commit()
     db.refresh(user)
     return {
@@ -351,6 +383,8 @@ async def update_profile(
         "username": user.username,
         "first_name": user.first_name,
         "last_name": user.last_name,
+        "display_timezone": get_display_timezone(db, user.id),
+        "display_time_format": get_display_time_format(db, user.id),
     }
 
 
@@ -364,11 +398,24 @@ async def get_settings(
     Returns effective values and user overrides (null = using server default).
     """
     enabled = get_garmin_to_strava_sync_enabled(current_user, db)
+    device = get_fit_device_settings(db, current_user.id)
     return {
         "garmin_to_strava_sync_disabled": not enabled,
-        "garmin_to_strava_sync_disabled_override": get_setting_override_bool(db, current_user.id, KEY_GARMIN_TO_STRAVA_SYNC_DISABLED),
+        "garmin_to_strava_sync_disabled_override": get_setting_override_bool(
+            db, current_user.id, KEY_GARMIN_TO_STRAVA_SYNC_DISABLED
+        ),
         "allow_export_without_gps": get_allow_export_without_gps(current_user, db),
-        "allow_export_without_gps_override": get_setting_override_bool(db, current_user.id, KEY_ALLOW_EXPORT_WITHOUT_GPS),
+        "allow_export_without_gps_override": get_setting_override_bool(
+            db, current_user.id, KEY_ALLOW_EXPORT_WITHOUT_GPS
+        ),
+        "sync_schedule_minutes": get_sync_schedule_minutes(db, current_user.id),
+        "fit_device_settings": {
+            "device_name": device.get("device_name") or None,
+            "serial_number": device.get("serial_number") or None,
+            "manufacturer_id": device.get("manufacturer_id") or None,
+            "software_version": device.get("software_version") or None,
+            "product_id": device.get("product_id") or None,
+        },
     }
 
 
@@ -384,16 +431,51 @@ async def update_settings(
         if not user:
             raise HTTPException(status_code=404, detail="User not found")
         if body.garmin_to_strava_sync_disabled is not None:
-            set_setting(db, user.id, KEY_GARMIN_TO_STRAVA_SYNC_DISABLED, "true" if body.garmin_to_strava_sync_disabled else "false")
+            set_setting(
+                db,
+                user.id,
+                KEY_GARMIN_TO_STRAVA_SYNC_DISABLED,
+                "true" if body.garmin_to_strava_sync_disabled else "false",
+            )
         if body.allow_export_without_gps is not None:
-            set_setting(db, user.id, KEY_ALLOW_EXPORT_WITHOUT_GPS, "true" if body.allow_export_without_gps else "false")
+            set_setting(
+                db,
+                user.id,
+                KEY_ALLOW_EXPORT_WITHOUT_GPS,
+                "true" if body.allow_export_without_gps else "false",
+            )
+        if body.sync_schedule_minutes is not None:
+            if body.sync_schedule_minutes in SYNC_SCHEDULE_CHOICES:
+                set_setting(db, user.id, KEY_SYNC_SCHEDULE_MINUTES, str(body.sync_schedule_minutes))
+            # else ignore invalid value
+        if body.fit_device_settings is not None:
+            data = get_fit_device_settings(db, user.id)
+            for k, v in body.fit_device_settings.model_dump().items():
+                if v is not None and (isinstance(v, str) and v.strip()):
+                    data[k] = v.strip()
+                elif k in data:
+                    data.pop(k, None)
+            set_fit_device_settings(db, user.id, data)
         db.commit()
         enabled = get_garmin_to_strava_sync_enabled(user, db)
+        device = get_fit_device_settings(db, user.id)
         return {
             "garmin_to_strava_sync_disabled": not enabled,
-            "garmin_to_strava_sync_disabled_override": get_setting_override_bool(db, user.id, KEY_GARMIN_TO_STRAVA_SYNC_DISABLED),
+            "garmin_to_strava_sync_disabled_override": get_setting_override_bool(
+                db, user.id, KEY_GARMIN_TO_STRAVA_SYNC_DISABLED
+            ),
             "allow_export_without_gps": get_allow_export_without_gps(user, db),
-            "allow_export_without_gps_override": get_setting_override_bool(db, user.id, KEY_ALLOW_EXPORT_WITHOUT_GPS),
+            "allow_export_without_gps_override": get_setting_override_bool(
+                db, user.id, KEY_ALLOW_EXPORT_WITHOUT_GPS
+            ),
+            "sync_schedule_minutes": get_sync_schedule_minutes(db, user.id),
+            "fit_device_settings": {
+                "device_name": device.get("device_name") or None,
+                "serial_number": device.get("serial_number") or None,
+                "manufacturer_id": device.get("manufacturer_id") or None,
+                "software_version": device.get("software_version") or None,
+                "product_id": device.get("product_id") or None,
+            },
         }
     except HTTPException:
         db.rollback()
@@ -402,6 +484,11 @@ async def update_settings(
         db.rollback()
         logger.exception("Failed to update user settings")
         msg = str(e)
-        if "garmin_to_strava_sync" in msg or "allow_export_without_gps" in msg or "does not exist" in msg or "column" in msg.lower():
+        if (
+            "garmin_to_strava_sync" in msg
+            or "allow_export_without_gps" in msg
+            or "does not exist" in msg
+            or "column" in msg.lower()
+        ):
             msg = "Database schema may be outdated. Run: alembic upgrade head"
         raise HTTPException(status_code=500, detail=msg)

--- a/backend/app/routes/sync.py
+++ b/backend/app/routes/sync.py
@@ -3,10 +3,13 @@ Sync management routes.
 """
 
 import logging
+import os
+import tempfile
 from datetime import datetime
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import Response
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
@@ -14,6 +17,7 @@ from app.database import get_db
 from app.utils.user_settings import get_garmin_to_strava_sync_enabled
 from app.middleware.auth import get_current_user
 from app.models import SyncLog, User
+from app.services.garmin_service import GarminService
 from app.services.garmin_to_strava_sync_service import GarminToStravaSyncService
 from app.services.sync_service import SyncService
 
@@ -241,6 +245,68 @@ async def get_sync_log_details(
         raise HTTPException(status_code=404, detail="Sync log not found")
 
     return sync_log
+
+
+@router.get("/history/{sync_log_id}/download-fit")
+async def download_sync_log_fit(
+    sync_log_id: int, current_user: User = Depends(get_current_user), db: Session = Depends(get_db)
+):
+    """
+    Download the FIT file for a successful sync log.
+    Strava → Garmin: regenerates FIT from Strava. Garmin → Strava: re-downloads from Garmin.
+    """
+    sync_log = (
+        db.query(SyncLog)
+        .filter(SyncLog.id == sync_log_id, SyncLog.user_id == current_user.id)
+        .first()
+    )
+    if not sync_log:
+        raise HTTPException(status_code=404, detail="Sync log not found")
+    if sync_log.status != "success":
+        raise HTTPException(status_code=400, detail="Only successful syncs can be downloaded")
+
+    activity_id = sync_log.source_activity_id
+    filename = f"activity-{activity_id}.fit"
+
+    if sync_log.sync_direction == "strava_to_garmin":
+        sync_service = SyncService(db, current_user)
+        fit_bytes = sync_service.get_fit_bytes_for_strava_activity(int(activity_id))
+        if not fit_bytes:
+            raise HTTPException(
+                status_code=502,
+                detail="Could not generate FIT file (activity or streams unavailable)",
+            )
+        return Response(
+            content=fit_bytes,
+            media_type="application/octet-stream",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+
+    if sync_log.sync_direction == "garmin_to_strava":
+        garmin_service = GarminService(db)
+        if not garmin_service.connect(current_user):
+            raise HTTPException(status_code=502, detail="Garmin not connected")
+        fd, temp_path = tempfile.mkstemp(suffix=".fit")
+        try:
+            os.close(fd)
+            path = garmin_service.download_activity_original(activity_id, temp_path)
+            if not path or not os.path.exists(path):
+                raise HTTPException(status_code=502, detail="Could not download FIT from Garmin")
+            with open(path, "rb") as f:
+                fit_bytes = f.read()
+            return Response(
+                content=fit_bytes,
+                media_type="application/octet-stream",
+                headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+            )
+        finally:
+            if os.path.exists(temp_path):
+                try:
+                    os.unlink(temp_path)
+                except OSError:
+                    pass
+
+    raise HTTPException(status_code=400, detail="Download not supported for this sync direction")
 
 
 @router.post("/history/{sync_log_id}/retry")

--- a/backend/app/routes/sync.py
+++ b/backend/app/routes/sync.py
@@ -6,7 +6,7 @@ import logging
 import os
 import tempfile
 from datetime import datetime
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
@@ -14,6 +14,7 @@ from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
 from app.database import get_db
+from app.utils.file_storage import get_file_path
 from app.utils.user_settings import get_garmin_to_strava_sync_enabled
 from app.middleware.auth import get_current_user
 from app.models import SyncLog, User
@@ -73,6 +74,11 @@ class SyncLogDetailResponse(BaseModel):
     error_message: Optional[str]
     activity_name: Optional[str]
     activity_type: Optional[str]
+    uploaded_file_extension: Optional[str]  # File type sent: "fit", "gpx", "tcx", etc.
+    uploaded_file_path: Optional[str]  # Path to stored file
+    file_available: bool  # Whether the file exists on disk and can be downloaded
+    strava_data: Optional[Dict]  # Raw Strava activity data
+    garmin_data: Optional[str]  # File summary or Garmin response data
     created_at: datetime
     completed_at: Optional[datetime]
 
@@ -244,7 +250,39 @@ async def get_sync_log_details(
     if not sync_log:
         raise HTTPException(status_code=404, detail="Sync log not found")
 
-    return sync_log
+    # Check if file exists on disk
+    file_available = False
+    if sync_log.uploaded_file_path and sync_log.uploaded_file_extension:
+        from app.utils.file_storage import get_file_path
+        try:
+            file_path = get_file_path(sync_log.uploaded_file_path)
+            file_available = file_path.exists()
+        except Exception as e:
+            logger.warning(f"Error checking file existence for sync_log {sync_log_id}: {e}")
+            file_available = False
+
+    # Create response using model_validate with additional field
+    response_data = {
+        "id": sync_log.id,
+        "sync_direction": sync_log.sync_direction,
+        "source_activity_id": sync_log.source_activity_id,
+        "target_activity_id": sync_log.target_activity_id,
+        "strava_activity_id": sync_log.strava_activity_id,
+        "garmin_activity_id": sync_log.garmin_activity_id,
+        "status": sync_log.status,
+        "error_message": sync_log.error_message,
+        "activity_name": sync_log.activity_name,
+        "activity_type": sync_log.activity_type,
+        "uploaded_file_extension": sync_log.uploaded_file_extension,
+        "uploaded_file_path": sync_log.uploaded_file_path,
+        "file_available": file_available,
+        "strava_data": sync_log.strava_data,
+        "garmin_data": sync_log.garmin_data,
+        "created_at": sync_log.created_at,
+        "completed_at": sync_log.completed_at,
+    }
+
+    return SyncLogDetailResponse(**response_data)
 
 
 @router.get("/history/{sync_log_id}/download-fit")
@@ -252,8 +290,8 @@ async def download_sync_log_fit(
     sync_log_id: int, current_user: User = Depends(get_current_user), db: Session = Depends(get_db)
 ):
     """
-    Download the FIT file for a successful sync log.
-    Strava → Garmin: regenerates FIT from Strava. Garmin → Strava: re-downloads from Garmin.
+    Download the file that was sent during sync. Returns the stored file when available,
+    otherwise regenerates (Strava→Garmin) or re-downloads (Garmin→Strava).
     """
     sync_log = (
         db.query(SyncLog)
@@ -266,6 +304,27 @@ async def download_sync_log_fit(
         raise HTTPException(status_code=400, detail="Only successful syncs can be downloaded")
 
     activity_id = sync_log.source_activity_id
+
+    # Serve stored file when available
+    if sync_log.uploaded_file_path and sync_log.uploaded_file_extension:
+        path = get_file_path(sync_log.uploaded_file_path)
+        if path.exists():
+            ext = sync_log.uploaded_file_extension.strip().lower()
+            media_type = {
+                "fit": "application/octet-stream",
+                "gpx": "application/gpx+xml",
+                "tcx": "application/vnd.garmin.tcx+xml",
+            }.get(ext, "application/octet-stream")
+            with open(path, "rb") as f:
+                file_bytes = f.read()
+            return Response(
+                content=file_bytes,
+                media_type=media_type,
+                headers={"Content-Disposition": f'attachment; filename="activity-{activity_id}.{ext}"'},
+            )
+        logger.warning(f"Stored file missing: {sync_log.uploaded_file_path}")
+
+    # Fallback for old sync logs without stored file
     filename = f"activity-{activity_id}.fit"
 
     if sync_log.sync_direction == "strava_to_garmin":
@@ -408,6 +467,15 @@ async def delete_sync_log(
         if not sync_log:
             raise HTTPException(status_code=404, detail="Sync log not found")
 
+        # Delete associated file if it exists
+        if sync_log.uploaded_file_path:
+            from app.utils.file_storage import delete_uploaded_file
+            try:
+                delete_uploaded_file(sync_log.uploaded_file_path)
+                logger.info(f"Deleted file for sync_log {sync_log_id}: {sync_log.uploaded_file_path}")
+            except Exception as e:
+                logger.warning(f"Failed to delete file for sync_log {sync_log_id}: {e}")
+
         # Delete the sync log
         db.delete(sync_log)
         db.commit()
@@ -474,9 +542,26 @@ async def bulk_delete_sync_logs(
         if count == 0:
             return {"message": "No sync logs found matching the criteria", "deleted_count": 0}
 
+        # Get sync logs to delete their associated files
+        sync_logs_to_delete = query.all()
+        from app.utils.file_storage import delete_uploaded_file
+        
+        # Delete associated files
+        files_deleted = 0
+        for sync_log in sync_logs_to_delete:
+            if sync_log.uploaded_file_path:
+                try:
+                    delete_uploaded_file(sync_log.uploaded_file_path)
+                    files_deleted += 1
+                except Exception as e:
+                    logger.warning(f"Failed to delete file for sync_log {sync_log.id}: {e}")
+
         # Delete matching logs
         query.delete(synchronize_session=False)
         db.commit()
+        
+        if files_deleted > 0:
+            logger.info(f"Deleted {files_deleted} associated file(s) during bulk delete")
 
         logger.info(
             f"Bulk deleted {count} sync logs for user {current_user.id} (status={status}, before_date={before_date}, strava_activity_id={strava_activity_id})"

--- a/backend/app/routes/sync.py
+++ b/backend/app/routes/sync.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
 from app.database import get_db
+from app.utils.user_settings import get_garmin_to_strava_sync_enabled
 from app.middleware.auth import get_current_user
 from app.models import SyncLog, User
 from app.services.garmin_to_strava_sync_service import GarminToStravaSyncService
@@ -127,6 +128,12 @@ async def manual_sync_garmin_to_strava(
 
     Requires: Bearer token authentication
     """
+    if not get_garmin_to_strava_sync_enabled(current_user, db):
+        raise HTTPException(
+            status_code=403,
+            detail="Garmin → Strava sync is disabled. Enable it in Settings to sync from Garmin to Strava.",
+        )
+
     user = current_user
 
     # Check if user has both Strava and Garmin configured

--- a/backend/app/routes/workouts.py
+++ b/backend/app/routes/workouts.py
@@ -1,0 +1,253 @@
+"""
+Routes for Garmin workout scheduling.
+"""
+
+import logging
+from datetime import date, timedelta
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, field_validator
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.middleware.auth import get_current_user
+from app.models import User
+from app.services.workout_schedule_service import WorkoutScheduleService
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+# ---------------------------------------------------------------------------
+# Request / response schemas
+# ---------------------------------------------------------------------------
+
+
+class CreateScheduleRequest(BaseModel):
+    workout_id: str
+    workout_name: str
+    days_of_week: List[int]  # 0=Mon … 6=Sun
+
+    @field_validator("days_of_week")
+    @classmethod
+    def validate_days(cls, v: List[int]) -> List[int]:
+        if not v:
+            raise ValueError("At least one day must be selected")
+        if any(d not in range(7) for d in v):
+            raise ValueError("Days must be integers 0–6 (Mon–Sun)")
+        return sorted(set(v))
+
+
+class ToggleScheduleRequest(BaseModel):
+    is_active: bool
+
+
+class SyncRequest(BaseModel):
+    date: Optional[str] = None  # ISO date YYYY-MM-DD; defaults to today
+
+
+class SyncNextDaysRequest(BaseModel):
+    days: int = 30  # number of days from today (inclusive)
+
+
+class WorkoutScheduleResponse(BaseModel):
+    id: int
+    workout_id: str
+    workout_name: str
+    days_of_week: List[int]
+    is_active: bool
+    created_at: str
+
+    model_config = {"from_attributes": True}
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/library")
+async def list_garmin_workouts(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> List[Dict[str, Any]]:
+    """
+    Fetch the current user's saved Garmin workout library.
+    Requires Garmin credentials to be connected.
+    """
+    if not current_user.garmin_auth:
+        raise HTTPException(status_code=400, detail="Garmin account not connected")
+
+    svc = WorkoutScheduleService(db, current_user)
+    workouts = svc.fetch_garmin_workouts()
+    if workouts is None:
+        raise HTTPException(
+            status_code=502,
+            detail="Could not connect to Garmin Connect. Please re-authenticate.",
+        )
+    return workouts
+
+
+@router.get("/schedules")
+async def list_schedules(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> List[Dict[str, Any]]:
+    """Return all workout schedules for the current user."""
+    svc = WorkoutScheduleService(db, current_user)
+    schedules = svc.list_schedules()
+    return [
+        {
+            "id": s.id,
+            "workout_id": s.workout_id,
+            "workout_name": s.workout_name,
+            "days_of_week": s.days_of_week,
+            "is_active": s.is_active,
+            "created_at": s.created_at.isoformat() if s.created_at else None,
+        }
+        for s in schedules
+    ]
+
+
+@router.post("/schedules", status_code=201)
+async def create_schedule(
+    body: CreateScheduleRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    """Create a new recurring workout schedule."""
+    if not current_user.garmin_auth:
+        raise HTTPException(status_code=400, detail="Garmin account not connected")
+
+    svc = WorkoutScheduleService(db, current_user)
+    try:
+        schedule = svc.create_schedule(
+            workout_id=body.workout_id,
+            workout_name=body.workout_name,
+            days_of_week=body.days_of_week,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    return {
+        "id": schedule.id,
+        "workout_id": schedule.workout_id,
+        "workout_name": schedule.workout_name,
+        "days_of_week": schedule.days_of_week,
+        "is_active": schedule.is_active,
+        "created_at": schedule.created_at.isoformat() if schedule.created_at else None,
+    }
+
+
+@router.patch("/schedules/{schedule_id}")
+async def toggle_schedule(
+    schedule_id: int,
+    body: ToggleScheduleRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    """Enable or disable a schedule."""
+    svc = WorkoutScheduleService(db, current_user)
+    schedule = svc.toggle_schedule(schedule_id, body.is_active)
+    if not schedule:
+        raise HTTPException(status_code=404, detail="Schedule not found")
+    return {
+        "id": schedule.id,
+        "workout_id": schedule.workout_id,
+        "workout_name": schedule.workout_name,
+        "days_of_week": schedule.days_of_week,
+        "is_active": schedule.is_active,
+        "created_at": schedule.created_at.isoformat() if schedule.created_at else None,
+    }
+
+
+@router.delete("/schedules/{schedule_id}")
+async def delete_schedule(
+    schedule_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> Dict[str, str]:
+    """Delete a workout schedule."""
+    svc = WorkoutScheduleService(db, current_user)
+    deleted = svc.delete_schedule(schedule_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Schedule not found")
+    return {"message": "Schedule deleted"}
+
+
+@router.post("/schedules/sync")
+async def sync_schedules(
+    body: SyncRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    """
+    Manually push all active schedules matching the given date (default: today)
+    to Garmin Connect.
+    """
+    if not current_user.garmin_auth:
+        raise HTTPException(status_code=400, detail="Garmin account not connected")
+
+    target: Optional[date] = None
+    if body.date:
+        try:
+            target = date.fromisoformat(body.date)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="date must be YYYY-MM-DD")
+
+    svc = WorkoutScheduleService(db, current_user)
+    try:
+        results = svc.apply_for_date(target)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+
+    skipped_count = sum(1 for r in results if r.get("skipped"))
+    success_count = sum(1 for r in results if r.get("success") and not r.get("skipped"))
+    failed_count = sum(1 for r in results if not r.get("success"))
+    return {
+        "date": (target or date.today()).isoformat(),
+        "applied": len(results) - skipped_count,
+        "skipped": skipped_count,
+        "succeeded": success_count,
+        "failed": failed_count,
+        "results": results,
+    }
+
+
+@router.post("/schedules/sync-month")
+async def sync_schedules_next_days(
+    body: SyncNextDaysRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    """
+    Push all active schedules for the next N days (default 30) starting today.
+    """
+    if not current_user.garmin_auth:
+        raise HTTPException(status_code=400, detail="Garmin account not connected")
+
+    if body.days < 1 or body.days > 365:
+        raise HTTPException(status_code=422, detail="days must be between 1 and 365")
+
+    today = date.today()
+    end = today + timedelta(days=body.days - 1)
+
+    svc = WorkoutScheduleService(db, current_user)
+    try:
+        results = svc.apply_for_next_days(body.days)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+
+    skipped_count = sum(1 for r in results if r.get("skipped"))
+    success_count = sum(1 for r in results if r.get("success") and not r.get("skipped"))
+    failed_count = sum(1 for r in results if not r.get("success"))
+    return {
+        "start": today.isoformat(),
+        "end": end.isoformat(),
+        "days": body.days,
+        "applied": len(results) - skipped_count,
+        "skipped": skipped_count,
+        "succeeded": success_count,
+        "failed": failed_count,
+        "results": results,
+    }

--- a/backend/app/services/garmin_service.py
+++ b/backend/app/services/garmin_service.py
@@ -2,22 +2,36 @@
 Garmin Connect service for authentication and activity upload.
 """
 
-import json
 import logging
+import os
 import threading
 import time
 import uuid
 from datetime import datetime
 from typing import Any, Dict, Optional, Tuple
 
-from garminconnect import Garmin, GarminConnectAuthenticationError, GarminConnectConnectionError
-from garth.exc import GarthException
+from garminconnect import (
+    Garmin,
+    GarminConnectAuthenticationError,
+    GarminConnectConnectionError,
+    GarminConnectTooManyRequestsError,
+)
 from sqlalchemy.orm import Session
 
 from app.models import GarminAuth, User
 from app.utils.crypto import decrypt, encrypt
 
 logger = logging.getLogger(__name__)
+
+# Root directory for per-user DI OAuth token files.
+# Mount this path as a persistent Docker volume so tokens survive container restarts.
+_TOKEN_ROOT = os.environ.get("GARMIN_TOKEN_DIR", "/backend/data/garmin_tokens")
+
+# Per-user rate-limit backoff: after a 429/auth failure on a fresh login, suppress
+# further fresh-login attempts for this many seconds to avoid Cloudflare blocks.
+_FRESH_LOGIN_COOLDOWN_SECONDS = 600  # 10 minutes
+_fresh_login_failed_at: Dict[int, float] = {}  # user_id → epoch timestamp of last failure
+_fresh_login_lock = threading.Lock()
 
 # In-memory store for MFA pending state (Garmin client + client_state not serializable).
 # Key: mfa_token (str), Value: dict with garmin, client_state, email, password, user_id, created_at
@@ -30,14 +44,39 @@ class GarminService:
     """Service for interacting with Garmin Connect."""
 
     def __init__(self, db: Session):
-        """
-        Initialize Garmin service.
-
-        Args:
-            db: Database session
-        """
         self.db = db
         self.client: Optional[Garmin] = None
+
+    # ------------------------------------------------------------------
+    # Token persistence helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _token_dir(user_id: int) -> str:
+        """Return (and create) the per-user token directory on disk."""
+        path = os.path.join(_TOKEN_ROOT, f"user_{user_id}")
+        os.makedirs(path, exist_ok=True)
+        return path
+
+    def _persist_tokens(self, garmin_client: Garmin, garmin_auth: GarminAuth) -> None:
+        """Write DI OAuth tokens to disk AND keep the DB column in sync.
+        Also clears any active rate-limit cooldown — valid tokens mean we're unblocked.
+        """
+        with _fresh_login_lock:
+            _fresh_login_failed_at.pop(garmin_auth.user_id, None)
+
+        token_dir = self._token_dir(garmin_auth.user_id)
+        try:
+            garmin_client.client.dump(token_dir)
+        except Exception as exc:
+            logger.warning(f"Could not write token file for user {garmin_auth.user_id}: {exc}")
+
+        try:
+            session_json = garmin_client.client.dumps()
+            garmin_auth.session_data = session_json
+            self.db.commit()
+        except Exception as exc:
+            logger.warning(f"Could not save session to DB for user {garmin_auth.user_id}: {exc}")
 
     def save_credentials(self, user: User, email: str, password: str) -> GarminAuth:
         """
@@ -104,6 +143,9 @@ class GarminService:
         try:
             client = Garmin(email=email, password=password, return_on_mfa=True)
             login_result = client.login()
+        except GarminConnectTooManyRequestsError as e:
+            logger.error(f"Garmin login (MFA flow) rate-limited: {e}")
+            raise
         except GarminConnectAuthenticationError as e:
             logger.error(f"Garmin login (MFA flow) auth failed: {e}")
             raise
@@ -112,12 +154,10 @@ class GarminService:
             raise
 
         if login_result and login_result[0] == "needs_mfa":
-            client_state = login_result[1]
             mfa_token = str(uuid.uuid4())
             with _MFA_LOCK:
                 _MFA_PENDING[mfa_token] = {
                     "garmin": client,
-                    "client_state": client_state,
                     "email": email,
                     "password": password,
                     "user_id": user_id,
@@ -156,39 +196,23 @@ class GarminService:
             return False, "MFA session expired. Please submit your Garmin credentials again."
 
         garmin_client = pending["garmin"]
-        client_state = pending["client_state"]
         email = pending["email"]
         password = pending["password"]
 
         try:
-            garmin_client.resume_login(client_state, mfa_code)
+            # client_state is now unused internally (MFA state lives on the client object)
+            garmin_client.resume_login(None, mfa_code)
         except GarminConnectAuthenticationError as e:
             logger.warning(f"MFA completion failed for user {user.id}: {e}")
             return False, "Invalid MFA code. Please try again."
         except GarminConnectConnectionError as e:
             logger.warning(f"MFA completion connection error for user {user.id}: {e}")
-            return False, str(e)
-        except GarthException as e:
-            msg = str(e).strip() if str(e) else ""
-            logger.warning(f"MFA completion (Garth) for user {user.id}: {e}")
-            if "csrf" in msg.lower() or "session" in msg.lower() or "expired" in msg.lower():
-                return (
-                    False,
-                    "Session expired. Please re-enter your Garmin credentials and try the code again.",
-                )
-            if "mfa" in msg.lower() or "code" in msg.lower() or "invalid" in msg.lower():
-                return False, "Invalid MFA code. Please try again."
+            msg = str(e).strip()
             if msg and len(msg) < 120 and "traceback" not in msg.lower():
                 return False, f"MFA verification failed: {msg}"
             return (
                 False,
                 "MFA verification failed. Please re-enter your Garmin credentials and try the code again.",
-            )
-        except AssertionError as e:
-            logger.warning(f"MFA completion assertion for user {user.id}: {e}")
-            return (
-                False,
-                "Session expired or invalid. Please re-enter your Garmin credentials and try again.",
             )
         except Exception as e:
             logger.exception(f"MFA completion error for user {user.id}: {type(e).__name__}: {e}")
@@ -205,10 +229,8 @@ class GarminService:
             )
 
         try:
-            session_json = garmin_client.garth.dumps()
             garmin_auth = self.save_credentials(user, email, password)
-            garmin_auth.session_data = session_json
-            self.db.commit()
+            self._persist_tokens(garmin_client, garmin_auth)
             logger.info(f"Garmin credentials and session saved for user {user.id} after MFA")
             return True, None
         except Exception as e:
@@ -234,62 +256,120 @@ class GarminService:
         email = decrypt(garmin_auth.encrypted_email)
         password = decrypt(garmin_auth.encrypted_password)
 
-        try:
-            # Try to restore session from database
-            if garmin_auth.session_data:
-                try:
-                    logger.info(
-                        f"Attempting to restore Garmin session from database for user {user.id}"
-                    )
-                    # Initialize Garmin client
-                    self.client = Garmin()
+        token_dir = self._token_dir(user.id)
+        token_file = os.path.join(token_dir, "garmin_tokens.json")
 
-                    # Load saved tokens into garth
-                    self.client.garth.loads(garmin_auth.session_data)
-
-                    logger.info(f"Successfully restored Garmin session for user {user.id}")
-                    return True
-                except Exception as e:
-                    logger.warning(f"Failed to restore session, will re-login: {e}")
-
-            # Fresh login required
-            logger.info(f"Performing fresh Garmin login for user {user.id}")
-            self.client = Garmin(email=email, password=password)
-
-            # Login returns tuple: (status, mfa_data) or (OAuth1Token, OAuth2Token).
-            # When MFA is required, garth returns ("needs_mfa", state); garminconnect
-            # may then access profile before checking, raising AssertionError.
+        # Strip corrupt/empty session_data so it is never used to seed a bad token file.
+        if garmin_auth.session_data is not None and not garmin_auth.session_data.strip():
+            logger.warning(
+                f"Clearing empty/corrupt session_data for user {user.id}"
+            )
+            garmin_auth.session_data = None
             try:
-                login_result = self.client.login()
-            except AssertionError as e:
-                if "OAuth1 token is required for OAuth2 refresh" in str(e):
-                    logger.error(
-                        "Garmin login failed for user %s (MFA/OAuth1): %s",
-                        user.id,
-                        e,
+                self.db.commit()
+            except Exception:
+                pass
+
+        try:
+            # Seed disk from DB on first run / fresh volume mount.
+            if garmin_auth.session_data and not os.path.exists(token_file):
+                try:
+                    with open(token_file, "w") as f:
+                        f.write(garmin_auth.session_data)
+                    logger.info(f"Seeded token file from DB for user {user.id}")
+                except Exception as seed_err:
+                    logger.warning(f"Could not seed token file: {seed_err}")
+
+            # Restore from disk — login() handles load + expiry check + proactive refresh.
+            if os.path.exists(token_file):
+                try:
+                    self.client = Garmin()
+                    self.client.login(token_dir)
+                    self._persist_tokens(self.client, garmin_auth)
+                    logger.info(f"Restored Garmin session for user {user.id}")
+                    return True
+                except (GarminConnectTooManyRequestsError, GarminConnectConnectionError) as e:
+                    # Rate-limit or network error — keep the token file (tokens may still be
+                    # valid once the throttle lifts) and bail out until next cycle.
+                    logger.warning(
+                        f"Garmin rate-limit/connection error while restoring session for "
+                        f"user {user.id}: {e}. Will retry next cycle."
                     )
                     return False
-                raise
+                except GarminConnectAuthenticationError as e:
+                    # Token file contains an incompatible format (e.g. old garth tokens).
+                    # This is a local data problem, not Garmin blocking us — delete the
+                    # bad file, wipe the DB copy, clear any rate-limit cooldown, and fall
+                    # through to attempt a fresh login immediately.
+                    logger.warning(
+                        f"Token file for user {user.id} has an incompatible format "
+                        f"({e}). Clearing stale data and attempting fresh login."
+                    )
+                    try:
+                        os.unlink(token_file)
+                    except OSError:
+                        pass
+                    try:
+                        garmin_auth.session_data = None
+                        self.db.commit()
+                    except Exception:
+                        pass
+                    with _fresh_login_lock:
+                        _fresh_login_failed_at.pop(user.id, None)
+                except Exception as e:
+                    logger.warning(
+                        f"Stale token file for user {user.id}: {e}. Removing and will "
+                        "attempt fresh login after cooldown."
+                    )
+                    try:
+                        os.unlink(token_file)
+                    except OSError:
+                        pass
 
-            # Check if MFA is required
-            if login_result and login_result[0] == "needs_mfa":
-                error_msg = "MFA/2FA is required for this Garmin account. Please disable 2FA or use app-specific password."
-                logger.error(f"{error_msg} for user {user.id}")
+            # Guard: suppress fresh logins while in the rate-limit cooldown window.
+            with _fresh_login_lock:
+                last_fail = _fresh_login_failed_at.get(user.id)
+            if last_fail and (time.time() - last_fail) < _FRESH_LOGIN_COOLDOWN_SECONDS:
+                remaining = int(_FRESH_LOGIN_COOLDOWN_SECONDS - (time.time() - last_fail))
+                logger.warning(
+                    f"Skipping fresh Garmin login for user {user.id} — still in "
+                    f"rate-limit cooldown ({remaining}s remaining). "
+                    "Re-authenticate via the app to reset."
+                )
                 return False
 
-            # Save tokens to database as JSON
-            session_json = self.client.garth.dumps()
-            garmin_auth.session_data = session_json
-            self.db.commit()
+            # Fresh login — only reached when no valid token file exists.
+            # return_on_mfa=True prevents a hard exception when MFA is required;
+            # instead we get ("needs_mfa",) back and can bail gracefully.
+            logger.info(f"Performing fresh Garmin login for user {user.id}")
+            self.client = Garmin(email=email, password=password, return_on_mfa=True)
+            login_result = self.client.login(token_dir)
 
-            logger.info(f"Successfully logged in to Garmin for user {user.id}")
+            if login_result and login_result[0] == "needs_mfa":
+                logger.error(
+                    f"MFA required for user {user.id} during background connect. "
+                    "Re-authenticate via the app."
+                )
+                return False
+
+            with _fresh_login_lock:
+                _fresh_login_failed_at.pop(user.id, None)
+            self._persist_tokens(self.client, garmin_auth)
+            logger.info(f"Fresh Garmin login succeeded for user {user.id}")
             return True
 
+        except (GarminConnectTooManyRequestsError, GarminConnectConnectionError) as e:
+            logger.error(
+                f"Garmin rate-limited / connection error for user {user.id}: {e}. "
+                f"Entering {_FRESH_LOGIN_COOLDOWN_SECONDS // 60}-minute cooldown."
+            )
+            with _fresh_login_lock:
+                _fresh_login_failed_at[user.id] = time.time()
+            return False
         except GarminConnectAuthenticationError as e:
             logger.error(f"Garmin authentication failed for user {user.id}: {e}")
-            return False
-        except GarminConnectConnectionError as e:
-            logger.error(f"Garmin connection error for user {user.id}: {e}")
+            with _fresh_login_lock:
+                _fresh_login_failed_at[user.id] = time.time()
             return False
         except Exception as e:
             logger.error(f"Error connecting to Garmin for user {user.id}: {e}", exc_info=True)
@@ -341,6 +421,121 @@ class GarminService:
             return None
         except Exception as e:
             logger.error(f"Error uploading activity: {e}", exc_info=True)
+            return None
+
+    def import_activity(self, file_path: str) -> Optional[Dict[str, Any]]:
+        """
+        Import activity file to Garmin Connect using the import endpoint.
+
+        Unlike upload_activity(), this uses the import-style endpoint with
+        Garmin Connect Mobile headers so the activity is treated as an import
+        and will NOT be re-exported to Strava (preventing ping-pong duplicates).
+
+        Args:
+            file_path: Path to activity file (.fit, .tcx, or .gpx)
+
+        Returns:
+            DetailedImportResult dict (with successes/failures/internalId) or None if error
+        """
+        if not self.client:
+            logger.error("Garmin client not connected")
+            return None
+
+        try:
+            import os
+
+            if not os.path.exists(file_path):
+                logger.error(f"Activity file does not exist: {file_path}")
+                return None
+
+            logger.info(f"Importing activity from {file_path} (will not be re-exported to Strava)")
+            result = self.client.import_activity(file_path)
+
+            if isinstance(result, dict):
+                return result
+            return vars(result) if hasattr(result, "__dict__") else {"raw_response": result}
+
+        except Exception as e:
+            # 409 Conflict means Garmin already has this activity — treat as duplicate not an error
+            if "409" in str(e) or "duplicate" in str(e).lower():
+                logger.warning(f"Activity already exists in Garmin (duplicate): {e}")
+                return {"duplicate": True, "message": str(e)}
+            logger.error(f"Error importing activity: {e}", exc_info=True)
+            return None
+
+    def get_workouts(self, limit: int = 200) -> Optional[list]:
+        """
+        Fetch all saved workouts from Garmin Connect.
+
+        Returns:
+            List of workout dicts (workoutId, name, sport, etc.) or None on error.
+        """
+        if not self.client:
+            logger.error("Garmin client not connected")
+            return None
+
+        try:
+            logger.info("Fetching Garmin workouts")
+            workouts = self.client.get_workouts(0, limit)
+            return workouts if isinstance(workouts, list) else []
+        except Exception as e:
+            logger.error(f"Error fetching Garmin workouts: {e}", exc_info=True)
+            return None
+
+    def get_scheduled_dates_for_workout(self, workout_id: str) -> set:
+        """
+        Fetch all dates on which a specific workout is already scheduled in Garmin.
+
+        Calls GET /workout-service/schedule/{workout_id} — returns a list of objects
+        like {"date": "YYYY-MM-DD", ...}.  Returns a set of ISO date strings so callers
+        can do O(1) membership tests.
+
+        Returns an empty set on any error (fail-open: we'd rather over-schedule than skip).
+        """
+        if not self.client:
+            return set()
+
+        try:
+            # garminconnect exposes low-level API access via connectapi()
+            data = self.client.connectapi(
+                f"/workout-service/schedule/{workout_id}"
+            )
+            if isinstance(data, list):
+                dates = {entry.get("date") for entry in data if entry.get("date")}
+                logger.debug(
+                    f"Workout {workout_id} already scheduled on {len(dates)} date(s): {sorted(dates)}"
+                )
+                return dates
+        except Exception as e:
+            logger.warning(
+                f"Could not fetch scheduled dates for workout {workout_id}: {e}. "
+                "Proceeding without Garmin-side duplicate check."
+            )
+        return set()
+
+    def schedule_workout(self, workout_id: str, date: str) -> Optional[dict]:
+        """
+        Schedule a Garmin workout on a specific date.
+
+        Args:
+            workout_id: Garmin workout ID string.
+            date: ISO date string (YYYY-MM-DD).
+
+        Returns:
+            Response dict on success, or None on error.
+        """
+        if not self.client:
+            logger.error("Garmin client not connected")
+            return None
+
+        try:
+            logger.info(f"Scheduling workout {workout_id} for {date}")
+            result = self.client.schedule_workout(workout_id, date)
+            if isinstance(result, dict):
+                return result
+            return {"scheduled": True}
+        except Exception as e:
+            logger.error(f"Error scheduling workout {workout_id} for {date}: {e}", exc_info=True)
             return None
 
     def get_activities(self, start_date: str, limit: int = 10) -> Optional[list]:
@@ -493,32 +688,14 @@ class GarminService:
         Returns:
             Tuple of (success: bool, error_message: Optional[str])
         """
-        _OAUTH1_REFRESH_MSG = "OAuth1 token is required for OAuth2 refresh"
-
         try:
             logger.info(f"Attempting to verify Garmin credentials for {email}")
 
-            # Use garminconnect with the correct login pattern
             client = Garmin(email=email, password=password)
+            login_result = client.login()
 
-            # Login returns tuple: (status, mfa_data) or (OAuth1Token, OAuth2Token)
-            # When MFA is required, garth returns ("needs_mfa", state) and then
-            # garminconnect may access profile before checking, triggering AssertionError
-            try:
-                login_result = client.login()
-            except AssertionError as e:
-                if _OAUTH1_REFRESH_MSG in str(e):
-                    error_msg = (
-                        "MFA/2FA is required for this account. "
-                        "Please disable 2FA or use an app-specific password."
-                    )
-                    logger.warning(f"Garmin login failed (OAuth1/MFA): {e}")
-                    return False, error_msg
-                raise
-
-            # Check if MFA is required
             if login_result and login_result[0] == "needs_mfa":
-                error_msg = "MFA/2FA is required for this account. Please disable 2FA or use app-specific password."
+                error_msg = "MFA/2FA is required for this account. Please disable 2FA or use an app-specific password."
                 logger.warning(error_msg)
                 return False, error_msg
 
@@ -533,15 +710,10 @@ class GarminService:
             error_msg = f"Connection error: {str(e)}"
             logger.error(error_msg)
             return False, error_msg
-        except AssertionError as e:
-            if _OAUTH1_REFRESH_MSG in str(e):
-                error_msg = (
-                    "MFA/2FA is required for this account. "
-                    "Please disable 2FA or use an app-specific password."
-                )
-                logger.warning(f"Garmin verify credentials failed (OAuth1/MFA): {e}")
-                return False, error_msg
-            raise
+        except GarminConnectTooManyRequestsError as e:
+            error_msg = f"Rate limit exceeded: {str(e)}"
+            logger.error(error_msg)
+            return False, error_msg
         except Exception as e:
             error_msg = f"{type(e).__name__}: {str(e) if str(e) else 'No details available'}"
             logger.error(f"Error verifying credentials: {error_msg}", exc_info=True)

--- a/backend/app/services/garmin_service.py
+++ b/backend/app/services/garmin_service.py
@@ -79,13 +79,13 @@ class GarminService:
         """Remove expired MFA pending entries."""
         now = time.time()
         with _MFA_LOCK:
-            expired = [k for k, v in _MFA_PENDING.items() if (now - v["created_at"]) > _MFA_TTL_SECONDS]
+            expired = [
+                k for k, v in _MFA_PENDING.items() if (now - v["created_at"]) > _MFA_TTL_SECONDS
+            ]
             for k in expired:
                 del _MFA_PENDING[k]
 
-    def start_login_with_mfa(
-        self, user_id: int, email: str, password: str
-    ) -> Tuple[str, Any]:
+    def start_login_with_mfa(self, user_id: int, email: str, password: str) -> Tuple[str, Any]:
         """
         Start Garmin login; supports MFA by returning early when MFA is required.
 
@@ -130,9 +130,7 @@ class GarminService:
         logger.info("Garmin login succeeded without MFA")
         return "success", client
 
-    def complete_mfa(
-        self, mfa_token: str, mfa_code: str, user: User
-    ) -> Tuple[bool, Optional[str]]:
+    def complete_mfa(self, mfa_token: str, mfa_code: str, user: User) -> Tuple[bool, Optional[str]]:
         """
         Complete Garmin login with MFA code and save credentials + session.
 
@@ -148,7 +146,10 @@ class GarminService:
         with _MFA_LOCK:
             pending = _MFA_PENDING.pop(mfa_token, None)
         if not pending:
-            return False, "MFA session expired or invalid. Please submit your Garmin credentials again."
+            return (
+                False,
+                "MFA session expired or invalid. Please submit your Garmin credentials again.",
+            )
 
         now = time.time()
         if (now - pending["created_at"]) > _MFA_TTL_SECONDS:
@@ -171,19 +172,33 @@ class GarminService:
             msg = str(e).strip() if str(e) else ""
             logger.warning(f"MFA completion (Garth) for user {user.id}: {e}")
             if "csrf" in msg.lower() or "session" in msg.lower() or "expired" in msg.lower():
-                return False, "Session expired. Please re-enter your Garmin credentials and try the code again."
+                return (
+                    False,
+                    "Session expired. Please re-enter your Garmin credentials and try the code again.",
+                )
             if "mfa" in msg.lower() or "code" in msg.lower() or "invalid" in msg.lower():
                 return False, "Invalid MFA code. Please try again."
             if msg and len(msg) < 120 and "traceback" not in msg.lower():
                 return False, f"MFA verification failed: {msg}"
-            return False, "MFA verification failed. Please re-enter your Garmin credentials and try the code again."
+            return (
+                False,
+                "MFA verification failed. Please re-enter your Garmin credentials and try the code again.",
+            )
         except AssertionError as e:
             logger.warning(f"MFA completion assertion for user {user.id}: {e}")
-            return False, "Session expired or invalid. Please re-enter your Garmin credentials and try again."
+            return (
+                False,
+                "Session expired or invalid. Please re-enter your Garmin credentials and try again.",
+            )
         except Exception as e:
             logger.exception(f"MFA completion error for user {user.id}: {type(e).__name__}: {e}")
             err_msg = str(e).strip() if str(e) else ""
-            if err_msg and len(err_msg) < 100 and "\n" not in err_msg and "traceback" not in err_msg.lower():
+            if (
+                err_msg
+                and len(err_msg) < 100
+                and "\n" not in err_msg
+                and "traceback" not in err_msg.lower()
+            ):
                 return False, f"Verification failed: {err_msg}"
             return False, (
                 "Verification failed. Try re-entering your Garmin credentials, then enter the new code from your app quickly."
@@ -310,19 +325,16 @@ class GarminService:
             logger.info(f"Uploading activity from {file_path}")
             upload_response = self.client.upload_activity(file_path)
 
-            logger.info(f"Upload response type: {type(upload_response)}")
-            logger.info(f"Upload response: {upload_response}")
-
-            # Parse response to extract activity ID
-            # Response format varies, could be dict or object with activity_id
+            # Return the JSON: Response object -> .json(), else dict as-is
+            if hasattr(upload_response, "json") and callable(getattr(upload_response, "json")):
+                return upload_response.json() if getattr(upload_response, "content", None) else {}
             if isinstance(upload_response, dict):
                 return upload_response
-            elif hasattr(upload_response, "__dict__"):
-                # Convert object to dict
-                return vars(upload_response)
-            else:
-                # Return as-is wrapped in dict
-                return {"raw_response": upload_response}
+            return (
+                vars(upload_response)
+                if hasattr(upload_response, "__dict__")
+                else {"raw_response": upload_response}
+            )
 
         except GarminConnectConnectionError as e:
             logger.error(f"Connection error uploading activity: {e}", exc_info=True)
@@ -552,21 +564,18 @@ class GarminService:
 
         try:
             logger.info(f"Uploading weight {weight_kg}kg to Garmin")
-            
-            # Timestamp format expected by garminconnect is not strictly documented in the method signature 
-            # we saw earlier (it said str | None), but usually it handles it. 
+
+            # Timestamp format expected by garminconnect is not strictly documented in the method signature
+            # we saw earlier (it said str | None), but usually it handles it.
             # If None, it uses current time.
-            
+
             # garminconnect.add_body_composition(timestamp, weight, ...)
             # timestamp can be ISO string or None
-            
+
             ts_str = timestamp.isoformat() if timestamp else None
-            
-            self.client.add_body_composition(
-                timestamp=ts_str,
-                weight=weight_kg
-            )
-            
+
+            self.client.add_body_composition(timestamp=ts_str, weight=weight_kg)
+
             logger.info("Successfully uploaded weight to Garmin")
             return True
 

--- a/backend/app/services/garmin_service.py
+++ b/backend/app/services/garmin_service.py
@@ -4,16 +4,26 @@ Garmin Connect service for authentication and activity upload.
 
 import json
 import logging
+import threading
+import time
+import uuid
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from garminconnect import Garmin, GarminConnectAuthenticationError, GarminConnectConnectionError
+from garth.exc import GarthException
 from sqlalchemy.orm import Session
 
 from app.models import GarminAuth, User
 from app.utils.crypto import decrypt, encrypt
 
 logger = logging.getLogger(__name__)
+
+# In-memory store for MFA pending state (Garmin client + client_state not serializable).
+# Key: mfa_token (str), Value: dict with garmin, client_state, email, password, user_id, created_at
+_MFA_PENDING: Dict[str, Dict[str, Any]] = {}
+_MFA_LOCK = threading.Lock()
+_MFA_TTL_SECONDS = 300  # 5 minutes
 
 
 class GarminService:
@@ -65,6 +75,131 @@ class GarminService:
         self.db.refresh(garmin_auth)
         return garmin_auth
 
+    def _mfa_cleanup_expired(self) -> None:
+        """Remove expired MFA pending entries."""
+        now = time.time()
+        with _MFA_LOCK:
+            expired = [k for k, v in _MFA_PENDING.items() if (now - v["created_at"]) > _MFA_TTL_SECONDS]
+            for k in expired:
+                del _MFA_PENDING[k]
+
+    def start_login_with_mfa(
+        self, user_id: int, email: str, password: str
+    ) -> Tuple[str, Any]:
+        """
+        Start Garmin login; supports MFA by returning early when MFA is required.
+
+        Args:
+            user_id: Current user id (for completing MFA later).
+            email: Garmin Connect email.
+            password: Garmin Connect password.
+
+        Returns:
+            ("mfa_required", mfa_token) when MFA code is needed; caller should
+            call complete_mfa(mfa_token, mfa_code, user_id) with the code.
+            ("success", garmin_client) when login completed without MFA; caller
+            should save credentials and session from the client.
+        """
+        self._mfa_cleanup_expired()
+        try:
+            client = Garmin(email=email, password=password, return_on_mfa=True)
+            login_result = client.login()
+        except GarminConnectAuthenticationError as e:
+            logger.error(f"Garmin login (MFA flow) auth failed: {e}")
+            raise
+        except GarminConnectConnectionError as e:
+            logger.error(f"Garmin login (MFA flow) connection error: {e}")
+            raise
+
+        if login_result and login_result[0] == "needs_mfa":
+            client_state = login_result[1]
+            mfa_token = str(uuid.uuid4())
+            with _MFA_LOCK:
+                _MFA_PENDING[mfa_token] = {
+                    "garmin": client,
+                    "client_state": client_state,
+                    "email": email,
+                    "password": password,
+                    "user_id": user_id,
+                    "created_at": time.time(),
+                }
+            logger.info(f"MFA required for Garmin login, token issued for user {user_id}")
+            return "mfa_required", mfa_token
+
+        # Login succeeded without MFA
+        logger.info("Garmin login succeeded without MFA")
+        return "success", client
+
+    def complete_mfa(
+        self, mfa_token: str, mfa_code: str, user: User
+    ) -> Tuple[bool, Optional[str]]:
+        """
+        Complete Garmin login with MFA code and save credentials + session.
+
+        Args:
+            mfa_token: Token returned from start_login_with_mfa when MFA was required.
+            mfa_code: MFA code from the user (e.g. from authenticator app).
+            user: User to attach Garmin credentials to.
+
+        Returns:
+            (True, None) on success; (False, error_message) on failure.
+        """
+        self._mfa_cleanup_expired()
+        with _MFA_LOCK:
+            pending = _MFA_PENDING.pop(mfa_token, None)
+        if not pending:
+            return False, "MFA session expired or invalid. Please submit your Garmin credentials again."
+
+        now = time.time()
+        if (now - pending["created_at"]) > _MFA_TTL_SECONDS:
+            return False, "MFA session expired. Please submit your Garmin credentials again."
+
+        garmin_client = pending["garmin"]
+        client_state = pending["client_state"]
+        email = pending["email"]
+        password = pending["password"]
+
+        try:
+            garmin_client.resume_login(client_state, mfa_code)
+        except GarminConnectAuthenticationError as e:
+            logger.warning(f"MFA completion failed for user {user.id}: {e}")
+            return False, "Invalid MFA code. Please try again."
+        except GarminConnectConnectionError as e:
+            logger.warning(f"MFA completion connection error for user {user.id}: {e}")
+            return False, str(e)
+        except GarthException as e:
+            msg = str(e).strip() if str(e) else ""
+            logger.warning(f"MFA completion (Garth) for user {user.id}: {e}")
+            if "csrf" in msg.lower() or "session" in msg.lower() or "expired" in msg.lower():
+                return False, "Session expired. Please re-enter your Garmin credentials and try the code again."
+            if "mfa" in msg.lower() or "code" in msg.lower() or "invalid" in msg.lower():
+                return False, "Invalid MFA code. Please try again."
+            if msg and len(msg) < 120 and "traceback" not in msg.lower():
+                return False, f"MFA verification failed: {msg}"
+            return False, "MFA verification failed. Please re-enter your Garmin credentials and try the code again."
+        except AssertionError as e:
+            logger.warning(f"MFA completion assertion for user {user.id}: {e}")
+            return False, "Session expired or invalid. Please re-enter your Garmin credentials and try again."
+        except Exception as e:
+            logger.exception(f"MFA completion error for user {user.id}: {type(e).__name__}: {e}")
+            err_msg = str(e).strip() if str(e) else ""
+            if err_msg and len(err_msg) < 100 and "\n" not in err_msg and "traceback" not in err_msg.lower():
+                return False, f"Verification failed: {err_msg}"
+            return False, (
+                "Verification failed. Try re-entering your Garmin credentials, then enter the new code from your app quickly."
+            )
+
+        try:
+            session_json = garmin_client.garth.dumps()
+            garmin_auth = self.save_credentials(user, email, password)
+            garmin_auth.session_data = session_json
+            self.db.commit()
+            logger.info(f"Garmin credentials and session saved for user {user.id} after MFA")
+            return True, None
+        except Exception as e:
+            logger.exception(f"Failed to save Garmin credentials after MFA: {e}")
+            return False, "Failed to save credentials. Please try again."
+
     def connect(self, user: User) -> bool:
         """
         Connect to Garmin Connect for a user.
@@ -106,8 +241,20 @@ class GarminService:
             logger.info(f"Performing fresh Garmin login for user {user.id}")
             self.client = Garmin(email=email, password=password)
 
-            # Login returns tuple: (status, mfa_data) where status can be "needs_mfa" or None
-            login_result = self.client.login()
+            # Login returns tuple: (status, mfa_data) or (OAuth1Token, OAuth2Token).
+            # When MFA is required, garth returns ("needs_mfa", state); garminconnect
+            # may then access profile before checking, raising AssertionError.
+            try:
+                login_result = self.client.login()
+            except AssertionError as e:
+                if "OAuth1 token is required for OAuth2 refresh" in str(e):
+                    logger.error(
+                        "Garmin login failed for user %s (MFA/OAuth1): %s",
+                        user.id,
+                        e,
+                    )
+                    return False
+                raise
 
             # Check if MFA is required
             if login_result and login_result[0] == "needs_mfa":
@@ -334,14 +481,28 @@ class GarminService:
         Returns:
             Tuple of (success: bool, error_message: Optional[str])
         """
+        _OAUTH1_REFRESH_MSG = "OAuth1 token is required for OAuth2 refresh"
+
         try:
             logger.info(f"Attempting to verify Garmin credentials for {email}")
 
             # Use garminconnect with the correct login pattern
             client = Garmin(email=email, password=password)
 
-            # Login returns tuple: (status, mfa_data)
-            login_result = client.login()
+            # Login returns tuple: (status, mfa_data) or (OAuth1Token, OAuth2Token)
+            # When MFA is required, garth returns ("needs_mfa", state) and then
+            # garminconnect may access profile before checking, triggering AssertionError
+            try:
+                login_result = client.login()
+            except AssertionError as e:
+                if _OAUTH1_REFRESH_MSG in str(e):
+                    error_msg = (
+                        "MFA/2FA is required for this account. "
+                        "Please disable 2FA or use an app-specific password."
+                    )
+                    logger.warning(f"Garmin login failed (OAuth1/MFA): {e}")
+                    return False, error_msg
+                raise
 
             # Check if MFA is required
             if login_result and login_result[0] == "needs_mfa":
@@ -360,6 +521,15 @@ class GarminService:
             error_msg = f"Connection error: {str(e)}"
             logger.error(error_msg)
             return False, error_msg
+        except AssertionError as e:
+            if _OAUTH1_REFRESH_MSG in str(e):
+                error_msg = (
+                    "MFA/2FA is required for this account. "
+                    "Please disable 2FA or use an app-specific password."
+                )
+                logger.warning(f"Garmin verify credentials failed (OAuth1/MFA): {e}")
+                return False, error_msg
+            raise
         except Exception as e:
             error_msg = f"{type(e).__name__}: {str(e) if str(e) else 'No details available'}"
             logger.error(f"Error verifying credentials: {error_msg}", exc_info=True)

--- a/backend/app/services/garmin_to_strava_sync_service.py
+++ b/backend/app/services/garmin_to_strava_sync_service.py
@@ -13,9 +13,10 @@ from sqlalchemy.orm import Session
 from app.models import ActivityFilter, SyncLog, User
 from app.services.garmin_service import GarminService
 from app.services.strava_service import StravaService
+from app.utils.fit_utils import NO_GPS_MESSAGE, fit_file_has_gps
+from app.utils.user_settings import get_allow_export_without_gps
 
 logger = logging.getLogger(__name__)
-
 
 class GarminToStravaSyncService:
     """Service for syncing activities from Garmin to Strava."""
@@ -271,6 +272,18 @@ class GarminToStravaSyncService:
             sync_log.gpx_data = f"FIT file downloaded: {fit_size} bytes"
             self.db.commit()
 
+            # 4b. If FIT has no GPS, respect "Enable export without GPS" (same setting as Strava→Garmin)
+            if not fit_file_has_gps(fit_file_path):
+                if not get_allow_export_without_gps(self.user, self.db):
+                    result["status"] = "skipped"
+                    result["message"] = NO_GPS_MESSAGE
+                    self._update_sync_log(sync_log, "skipped", result["message"])
+                    logger.info(result["message"])
+                    return result
+                logger.info(
+                    f"FIT has no GPS for activity {garmin_activity_id}; uploading anyway (export without GPS enabled)"
+                )
+
             # 5. Upload to Strava
             logger.info(f"Uploading activity to Strava")
             upload_result = self.strava_service.upload_activity(
@@ -282,6 +295,13 @@ class GarminToStravaSyncService:
 
             if not upload_result or not upload_result.get("success"):
                 error_msg = upload_result.get("error") if upload_result else "Unknown error"
+                # Strava rejects no-GPS uploads; show friendly message
+                err_lower = error_msg.lower()
+                if "gps" in err_lower or "no gps" in err_lower or "gps data" in err_lower:
+                    result["status"] = "skipped"
+                    result["message"] = NO_GPS_MESSAGE
+                    self._update_sync_log(sync_log, "skipped", result["message"])
+                    return result
                 result["message"] = f"Failed to upload activity to Strava: {error_msg}"
                 self._update_sync_log(sync_log, "failed", result["message"])
                 return result

--- a/backend/app/services/garmin_to_strava_sync_service.py
+++ b/backend/app/services/garmin_to_strava_sync_service.py
@@ -267,9 +267,23 @@ class GarminToStravaSyncService:
                 self._update_sync_log(sync_log, "failed", result["message"])
                 return result
 
-            # Store FIT file info
+            # Store FIT file info and save to disk for download feature
             fit_size = os.path.getsize(fit_file_path)
-            sync_log.gpx_data = f"FIT file downloaded: {fit_size} bytes"
+            sync_log.garmin_data = f"FIT file downloaded: {fit_size} bytes"
+            
+            # Read file bytes and save to disk
+            with open(fit_file_path, "rb") as f:
+                fit_bytes = f.read()
+            
+            try:
+                from app.utils.file_storage import save_uploaded_file
+                file_path = save_uploaded_file(fit_bytes, sync_log.id, "fit")
+                sync_log.uploaded_file_path = file_path
+                sync_log.uploaded_file_extension = "fit"
+            except Exception as e:
+                logger.warning(f"Failed to save file to disk: {e}", exc_info=True)
+                # Continue with sync even if file storage fails
+            
             self.db.commit()
 
             # 4b. If FIT has no GPS, respect "Enable export without GPS" (same setting as Strava→Garmin)

--- a/backend/app/services/strava_service.py
+++ b/backend/app/services/strava_service.py
@@ -88,16 +88,20 @@ class StravaService:
         Returns:
             Created or updated StravaAuth object
         """
-        # Check if auth already exists
-        strava_auth = self.db.query(StravaAuth).filter(StravaAuth.user_id == user.id).first()
-
-        # Extract athlete ID
+        # Extract athlete ID first so we can use it in the duplicate-safe lookup below.
         if athlete:
             athlete_id = str(athlete.id)
         else:
             # Fallback to token response if athlete not provided
             athlete_info = token_response.get("athlete", {})
             athlete_id = str(athlete_info.get("id", "unknown"))
+
+        # Check if auth already exists — search by user_id first, then fall back to
+        # athlete_id so reconnecting the same Strava account never causes a UniqueViolation.
+        strava_auth = (
+            self.db.query(StravaAuth).filter(StravaAuth.user_id == user.id).first()
+            or self.db.query(StravaAuth).filter(StravaAuth.athlete_id == athlete_id).first()
+        )
 
         expires_at = datetime.fromtimestamp(token_response["expires_at"])
 

--- a/backend/app/services/strava_service.py
+++ b/backend/app/services/strava_service.py
@@ -211,7 +211,16 @@ class StravaService:
             return None
 
         try:
-            types = ["time", "latlng", "altitude", "heartrate", "cadence", "watts", "temp"]
+            types = [
+                "time",
+                "latlng",
+                "altitude",
+                "heartrate",
+                "cadence",
+                "watts",
+                "temp",
+                "velocity_smooth",
+            ]
             streams = client.get_activity_streams(activity_id, types=types)
             return streams
         except Exception as e:

--- a/backend/app/services/strava_service.py
+++ b/backend/app/services/strava_service.py
@@ -143,6 +143,12 @@ class StravaService:
 
         client = Client()
         client.access_token = strava_auth.access_token
+        client.refresh_token = strava_auth.refresh_token
+        # Set client_id and client_secret so stravalib can auto-refresh if needed
+        client.client_id = settings.STRAVA_CLIENT_ID
+        client.client_secret = settings.STRAVA_CLIENT_SECRET
+        # Set token_expires timestamp (Unix timestamp) to enable auto-refresh
+        client.token_expires = int(strava_auth.expires_at.timestamp())
         return client
 
     def _refresh_token(self, strava_auth: StravaAuth) -> StravaAuth:

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -15,6 +15,7 @@ from app.models import ActivityFilter, SyncLog, User
 from app.services.garmin_service import GarminService
 from app.services.strava_service import StravaService
 from app.utils.activity_converter import ActivityConverter
+from app.utils.user_settings import get_allow_export_without_gps
 
 logger = logging.getLogger(__name__)
 
@@ -240,16 +241,27 @@ class SyncService:
                 logger.info(result["message"])
                 return result
 
-            # 3. Fetch activity streams
+            # 3. Fetch activity streams (optional for activities without GPS, e.g. indoor/treadmill)
             logger.info(f"Fetching activity streams for {strava_activity_id}")
             streams = self.strava_service.get_activity_streams(self.user, strava_activity_id)
+            if streams is None:
+                streams = {}
 
-            if not streams or "latlng" not in streams:
-                result["message"] = "No GPS data available for this activity"
-                self._update_sync_log(sync_log, "failed", result["message"])
-                return result
+            has_gps = streams and "latlng" in streams and streams.get("latlng")
+            if not has_gps:
+                if not get_allow_export_without_gps(self.user, self.db):
+                    result["status"] = "skipped"
+                    result["message"] = (
+                        "Activity has no GPS. Enable 'Export without GPS' in Settings to sync indoor or manual activities to Garmin."
+                    )
+                    self._update_sync_log(sync_log, "skipped", result["message"])
+                    logger.info(result["message"])
+                    return result
+                logger.info(
+                    f"No GPS stream for activity {strava_activity_id}; syncing as summary-only (indoor/manual)"
+                )
 
-            # 4. Convert to FIT format
+            # 4. Convert to FIT format (converter supports no-GPS via summary + optional streams)
             logger.info(f"Converting activity to FIT format")
             fit_data = self.converter.strava_to_fit(activity, streams)
 
@@ -257,7 +269,7 @@ class SyncService:
             if isinstance(fit_data, bytes):
                 num_points = (
                     len(streams.get("latlng").data)
-                    if "latlng" in streams and streams.get("latlng")
+                    if streams and "latlng" in streams and streams.get("latlng")
                     else 0
                 )
                 fit_summary = {

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -356,33 +356,38 @@ class SyncService:
                     self._update_sync_log(sync_log, "failed", result["message"])
                     return result
 
-                # 7. Upload to Garmin
-                logger.info(f"Uploading activity to Garmin Connect (format: {file_extension})")
-                upload_response = self.garmin_service.upload_activity(
-                    temp_file_path, f".{file_extension}"
-                )
+                # 7. Import to Garmin (import endpoint prevents Garmin re-exporting to Strava)
+                logger.info(f"Importing activity to Garmin Connect (format: {file_extension})")
+                upload_response = self.garmin_service.import_activity(temp_file_path)
 
                 if not upload_response:
-                    result["message"] = "Failed to upload activity to Garmin (no response)"
+                    result["message"] = "Failed to import activity to Garmin (no response)"
                     self._update_sync_log(sync_log, "failed", result["message"])
                     return result
                 if upload_response.get("error"):
-                    msg = upload_response.get("message") or "Failed to upload activity to Garmin"
+                    msg = upload_response.get("message") or "Failed to import activity to Garmin"
                     details = upload_response.get("details")
                     result["message"] = f"{msg}. {details}" if details else msg
                     self._update_sync_log(sync_log, "failed", result["message"])
                     return result
 
                 # 8. Success!
-                # Try different possible keys for activity ID
-                garmin_activity_id = (
-                    upload_response.get("activity_id")
-                    or upload_response.get("activityId")
-                    or upload_response.get("id")
-                    or upload_response.get("activityID")
-                )
+                # import_activity() returns DetailedImportResult; extract the internal activity ID
+                # from the first success entry when present, otherwise fall back to top-level keys.
+                garmin_activity_id = None
+                detailed = upload_response.get("detailedImportResult", {})
+                successes = detailed.get("successes", [])
+                if successes:
+                    garmin_activity_id = successes[0].get("internalId")
+                if not garmin_activity_id:
+                    garmin_activity_id = (
+                        upload_response.get("activity_id")
+                        or upload_response.get("activityId")
+                        or upload_response.get("id")
+                        or upload_response.get("activityID")
+                    )
 
-                logger.info(f"Upload response keys: {list(upload_response.keys())}")
+                logger.info(f"Import response keys: {list(upload_response.keys())}")
                 logger.info(f"Extracted activity ID: {garmin_activity_id}")
 
                 result["status"] = "success"

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -15,7 +15,11 @@ from app.models import ActivityFilter, SyncLog, User
 from app.services.garmin_service import GarminService
 from app.services.strava_service import StravaService
 from app.utils.activity_converter import ActivityConverter
-from app.utils.user_settings import get_allow_export_without_gps, get_fit_device_settings
+from app.utils.file_storage import save_uploaded_file
+from app.utils.user_settings import (
+    get_allow_export_without_gps,
+    get_fit_device_settings,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -261,15 +265,21 @@ class SyncService:
                     f"No GPS stream for activity {strava_activity_id}; syncing as summary-only (indoor/manual)"
                 )
 
-            # 4. Convert to FIT format (converter supports no-GPS via summary + optional streams)
-            logger.info(f"Converting activity to FIT format")
+            # 4. Build FIT from streams
+            logger.info("Converting activity to FIT format")
             device_settings = get_fit_device_settings(self.db, self.user.id)
             fit_data = self.converter.strava_to_fit(
                 activity, streams, device_settings=device_settings
             )
 
-            # Store FIT data summary for debugging (not the full binary data)
+            file_bytes = None
+            file_extension = None
+
             if isinstance(fit_data, bytes):
+                file_bytes = fit_data
+                file_extension = "fit"
+
+                # Store FIT data summary for debugging (not the full binary data)
                 num_points = (
                     len(streams.get("latlng").data)
                     if streams and "latlng" in streams and streams.get("latlng")
@@ -294,14 +304,48 @@ class SyncService:
                         else None
                     ),
                 }
-                sync_log.gpx_data = str(fit_summary)
+                sync_log.garmin_data = str(fit_summary)
             else:
-                sync_log.gpx_data = str(fit_data)
-            self.db.commit()
+                sync_log.garmin_data = str(fit_data)
+                result["message"] = "Failed to generate FIT file"
+                self._update_sync_log(sync_log, "failed", result["message"])
+                return result
+
+            if not file_bytes or not file_extension:
+                result["message"] = "Failed to prepare file for upload"
+                self._update_sync_log(sync_log, "failed", result["message"])
+                return result
+
+            # Store file to disk for download feature (before upload)
+            try:
+                # Ensure extension is clean (lowercase, no whitespace)
+                file_extension = file_extension.strip().lower() if file_extension else None
+
+                logger.info(
+                    f"Saving file for sync_log {sync_log.id}: "
+                    f"extension={file_extension}, size={len(file_bytes)} bytes"
+                )
+
+                if not file_extension:
+                    logger.error(f"File extension is None or empty for sync_log {sync_log.id}")
+                    raise ValueError("File extension cannot be None or empty")
+
+                file_path = save_uploaded_file(file_bytes, sync_log.id, file_extension)
+                sync_log.uploaded_file_path = file_path
+                sync_log.uploaded_file_extension = file_extension
+                self.db.commit()
+                logger.info(
+                    f"Saved file: path={file_path}, extension={sync_log.uploaded_file_extension}"
+                )
+            except Exception as e:
+                logger.warning(f"Failed to save file to disk: {e}", exc_info=True)
+                # Continue with sync even if file storage fails
 
             # 5. Save to temporary file
-            with tempfile.NamedTemporaryFile(mode="wb", suffix=".fit", delete=False) as temp_file:
-                temp_file.write(fit_data)
+            with tempfile.NamedTemporaryFile(
+                mode="wb", suffix=f".{file_extension}", delete=False
+            ) as temp_file:
+                temp_file.write(file_bytes)
                 temp_file_path = temp_file.name
 
             try:
@@ -313,8 +357,10 @@ class SyncService:
                     return result
 
                 # 7. Upload to Garmin
-                logger.info(f"Uploading activity to Garmin Connect")
-                upload_response = self.garmin_service.upload_activity(temp_file_path, ".fit")
+                logger.info(f"Uploading activity to Garmin Connect (format: {file_extension})")
+                upload_response = self.garmin_service.upload_activity(
+                    temp_file_path, f".{file_extension}"
+                )
 
                 if not upload_response:
                     result["message"] = "Failed to upload activity to Garmin (no response)"
@@ -342,6 +388,30 @@ class SyncService:
                 result["status"] = "success"
                 result["message"] = "Activity synced successfully"
                 result["garmin_activity_id"] = garmin_activity_id
+
+                # Store Garmin upload response in garmin_data (extend existing summary if present)
+                try:
+                    import json
+
+                    existing_data = {}
+                    if sync_log.garmin_data:
+                        try:
+                            # Try to parse existing garmin_data as JSON
+                            existing_data = json.loads(
+                                sync_log.garmin_data.replace("'", '"')
+                                .replace("None", "null")
+                                .replace("True", "true")
+                                .replace("False", "false")
+                            )
+                        except Exception:
+                            # If parsing fails, keep as summary string
+                            existing_data = {"summary": sync_log.garmin_data}
+
+                    # Add Garmin response
+                    existing_data["garmin_upload_response"] = upload_response
+                    sync_log.garmin_data = json.dumps(existing_data, default=str)
+                except Exception as e:
+                    logger.warning(f"Failed to store Garmin upload response: {e}")
 
                 self._update_sync_log(
                     sync_log,

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -15,7 +15,7 @@ from app.models import ActivityFilter, SyncLog, User
 from app.services.garmin_service import GarminService
 from app.services.strava_service import StravaService
 from app.utils.activity_converter import ActivityConverter
-from app.utils.user_settings import get_allow_export_without_gps
+from app.utils.user_settings import get_allow_export_without_gps, get_fit_device_settings
 
 logger = logging.getLogger(__name__)
 
@@ -263,7 +263,10 @@ class SyncService:
 
             # 4. Convert to FIT format (converter supports no-GPS via summary + optional streams)
             logger.info(f"Converting activity to FIT format")
-            fit_data = self.converter.strava_to_fit(activity, streams)
+            device_settings = get_fit_device_settings(self.db, self.user.id)
+            fit_data = self.converter.strava_to_fit(
+                activity, streams, device_settings=device_settings
+            )
 
             # Store FIT data summary for debugging (not the full binary data)
             if isinstance(fit_data, bytes):
@@ -314,7 +317,13 @@ class SyncService:
                 upload_response = self.garmin_service.upload_activity(temp_file_path, ".fit")
 
                 if not upload_response:
-                    result["message"] = "Failed to upload activity to Garmin"
+                    result["message"] = "Failed to upload activity to Garmin (no response)"
+                    self._update_sync_log(sync_log, "failed", result["message"])
+                    return result
+                if upload_response.get("error"):
+                    msg = upload_response.get("message") or "Failed to upload activity to Garmin"
+                    details = upload_response.get("details")
+                    result["message"] = f"{msg}. {details}" if details else msg
                     self._update_sync_log(sync_log, "failed", result["message"])
                     return result
 
@@ -366,6 +375,27 @@ class SyncService:
                 logger.error(f"Error updating sync log: {update_error}")
 
         return result
+
+    def get_fit_bytes_for_strava_activity(self, strava_activity_id: int) -> Optional[bytes]:
+        """
+        Fetch activity and streams from Strava and generate FIT file bytes.
+        Used for download-from-sync-log (no upload, no sync log update).
+        """
+        try:
+            activity = self.strava_service.get_activity(self.user, strava_activity_id)
+            if not activity:
+                return None
+            streams = self.strava_service.get_activity_streams(self.user, strava_activity_id)
+            device_settings = get_fit_device_settings(self.db, self.user.id)
+            fit_data = self.converter.strava_to_fit(
+                activity, streams or {}, device_settings=device_settings
+            )
+            return fit_data if isinstance(fit_data, bytes) else None
+        except Exception as e:
+            logger.warning(
+                f"Failed to generate FIT for activity {strava_activity_id}: {e}", exc_info=True
+            )
+            return None
 
     def _update_sync_log(
         self, sync_log: SyncLog, status: str, message: str, garmin_activity_id: Optional[str] = None

--- a/backend/app/services/workout_schedule_service.py
+++ b/backend/app/services/workout_schedule_service.py
@@ -1,0 +1,339 @@
+"""
+Service for managing and applying recurring Garmin workout schedules.
+"""
+
+import calendar
+import logging
+from datetime import date, datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.models import ScheduledWorkoutInstance, User, WorkoutSchedule
+from app.services.garmin_service import GarminService
+
+logger = logging.getLogger(__name__)
+
+# Day-name labels matching Python's date.weekday() (0=Mon … 6=Sun)
+DAY_NAMES = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+
+
+def _ensure_instance_recorded(db, user_id: int, workout_id: str, date_str: str) -> None:
+    """Insert a ScheduledWorkoutInstance row if one doesn't already exist."""
+    from sqlalchemy.exc import IntegrityError
+
+    existing = (
+        db.query(ScheduledWorkoutInstance)
+        .filter(
+            ScheduledWorkoutInstance.user_id == user_id,
+            ScheduledWorkoutInstance.workout_id == workout_id,
+            ScheduledWorkoutInstance.scheduled_date == date_str,
+        )
+        .first()
+    )
+    if existing:
+        return
+    try:
+        db.add(ScheduledWorkoutInstance(
+            user_id=user_id,
+            workout_id=workout_id,
+            scheduled_date=date_str,
+        ))
+        db.commit()
+    except IntegrityError:
+        db.rollback()  # race condition — another request already inserted it
+
+
+class WorkoutScheduleService:
+    """CRUD and application logic for recurring workout schedules."""
+
+    def __init__(self, db: Session, user: User) -> None:
+        self.db = db
+        self.user = user
+        self.garmin_service = GarminService(db)
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    def list_schedules(self) -> List[WorkoutSchedule]:
+        return (
+            self.db.query(WorkoutSchedule)
+            .filter(WorkoutSchedule.user_id == self.user.id)
+            .order_by(WorkoutSchedule.created_at.desc())
+            .all()
+        )
+
+    def create_schedule(
+        self, workout_id: str, workout_name: str, days_of_week: List[int]
+    ) -> WorkoutSchedule:
+        """
+        Create a new recurring workout schedule.
+
+        Args:
+            workout_id: Garmin workout ID.
+            workout_name: Human-readable workout name (cached locally).
+            days_of_week: List of ints (0=Mon … 6=Sun).
+        """
+        if not days_of_week:
+            raise ValueError("At least one day must be selected")
+        invalid = [d for d in days_of_week if d not in range(7)]
+        if invalid:
+            raise ValueError(f"Invalid day values: {invalid}")
+
+        schedule = WorkoutSchedule(
+            user_id=self.user.id,
+            workout_id=str(workout_id),
+            workout_name=workout_name,
+            days_of_week=sorted(set(days_of_week)),
+        )
+        self.db.add(schedule)
+        self.db.commit()
+        self.db.refresh(schedule)
+        logger.info(
+            f"Created workout schedule {schedule.id} for user {self.user.id}: "
+            f"'{workout_name}' on days {schedule.days_of_week}"
+        )
+        return schedule
+
+    def delete_schedule(self, schedule_id: int) -> bool:
+        schedule = (
+            self.db.query(WorkoutSchedule)
+            .filter(
+                WorkoutSchedule.id == schedule_id,
+                WorkoutSchedule.user_id == self.user.id,
+            )
+            .first()
+        )
+        if not schedule:
+            return False
+        self.db.delete(schedule)
+        self.db.commit()
+        logger.info(f"Deleted workout schedule {schedule_id} for user {self.user.id}")
+        return True
+
+    def toggle_schedule(self, schedule_id: int, is_active: bool) -> Optional[WorkoutSchedule]:
+        schedule = (
+            self.db.query(WorkoutSchedule)
+            .filter(
+                WorkoutSchedule.id == schedule_id,
+                WorkoutSchedule.user_id == self.user.id,
+            )
+            .first()
+        )
+        if not schedule:
+            return None
+        schedule.is_active = is_active
+        schedule.updated_at = datetime.utcnow()
+        self.db.commit()
+        self.db.refresh(schedule)
+        return schedule
+
+    # ------------------------------------------------------------------
+    # Garmin API helpers
+    # ------------------------------------------------------------------
+
+    def fetch_garmin_workouts(self) -> Optional[List[Dict[str, Any]]]:
+        """Connect to Garmin and return the full workout library."""
+        if not self.garmin_service.connect(self.user):
+            logger.error(f"Could not connect to Garmin for user {self.user.id}")
+            return None
+        return self.garmin_service.get_workouts()
+
+    # ------------------------------------------------------------------
+    # Schedule application
+    # ------------------------------------------------------------------
+
+    def apply_for_date(self, target_date: Optional[date] = None) -> List[Dict[str, Any]]:
+        """
+        Push all active schedules whose day_of_week matches target_date to Garmin.
+
+        Returns a list of per-schedule result dicts:
+            {"date", "schedule_id", "workout_name", "success", "result"|"error"}
+        """
+        if target_date is None:
+            target_date = date.today()
+
+        if not self.garmin_service.connect(self.user):
+            raise RuntimeError("Could not connect to Garmin Connect")
+
+        # Fetch Garmin-side scheduled dates for duplicate detection
+        active_schedules = (
+            self.db.query(WorkoutSchedule)
+            .filter(
+                WorkoutSchedule.user_id == self.user.id,
+                WorkoutSchedule.is_active.is_(True),
+            )
+            .all()
+        )
+        garmin_scheduled: Dict[str, set] = {
+            s.workout_id: self.garmin_service.get_scheduled_dates_for_workout(s.workout_id)
+            for s in active_schedules
+        }
+        return self._apply_date_connected(target_date, garmin_scheduled)
+
+    def _apply_date_connected(
+        self,
+        target_date: date,
+        garmin_scheduled: Optional[Dict[str, set]] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Apply schedules for a single date, assuming Garmin is already connected.
+
+        garmin_scheduled: pre-fetched map of {workout_id: set_of_iso_date_strings}
+            from Garmin's schedule endpoint. When provided, used to skip workouts
+            that are already on the Garmin calendar (including manually-scheduled ones).
+        """
+        if garmin_scheduled is None:
+            garmin_scheduled = {}
+
+        day_of_week = target_date.weekday()  # 0=Mon … 6=Sun
+        date_str = target_date.isoformat()
+
+        active_schedules = (
+            self.db.query(WorkoutSchedule)
+            .filter(
+                WorkoutSchedule.user_id == self.user.id,
+                WorkoutSchedule.is_active.is_(True),
+            )
+            .all()
+        )
+
+        matching = [s for s in active_schedules if day_of_week in (s.days_of_week or [])]
+
+        if not matching:
+            logger.debug(
+                f"No active schedules for user {self.user.id} on "
+                f"{DAY_NAMES[day_of_week]} ({date_str})"
+            )
+            return []
+
+        results: List[Dict[str, Any]] = []
+        for schedule in matching:
+            # 1. Check Garmin's own calendar (catches manually-scheduled workouts too)
+            if date_str in garmin_scheduled.get(schedule.workout_id, set()):
+                logger.debug(
+                    f"Skipping '{schedule.workout_name}' on {date_str} — already on Garmin calendar"
+                )
+                # Sync our local DB so future runs skip the API call
+                _ensure_instance_recorded(self.db, self.user.id, schedule.workout_id, date_str)
+                results.append(
+                    {
+                        "date": date_str,
+                        "schedule_id": schedule.id,
+                        "workout_name": schedule.workout_name,
+                        "success": True,
+                        "skipped": True,
+                        "reason": "already on Garmin calendar",
+                    }
+                )
+                continue
+
+            # 2. Check our local DB (fast path for workouts we previously pushed)
+            already_local = (
+                self.db.query(ScheduledWorkoutInstance)
+                .filter(
+                    ScheduledWorkoutInstance.user_id == self.user.id,
+                    ScheduledWorkoutInstance.workout_id == schedule.workout_id,
+                    ScheduledWorkoutInstance.scheduled_date == date_str,
+                )
+                .first()
+            )
+            if already_local:
+                logger.debug(
+                    f"Skipping '{schedule.workout_name}' on {date_str} — in local record"
+                )
+                results.append(
+                    {
+                        "date": date_str,
+                        "schedule_id": schedule.id,
+                        "workout_name": schedule.workout_name,
+                        "success": True,
+                        "skipped": True,
+                        "reason": "already scheduled",
+                    }
+                )
+                continue
+
+            try:
+                result = self.garmin_service.schedule_workout(schedule.workout_id, date_str)
+                if result is not None:
+                    _ensure_instance_recorded(self.db, self.user.id, schedule.workout_id, date_str)
+
+                results.append(
+                    {
+                        "date": date_str,
+                        "schedule_id": schedule.id,
+                        "workout_name": schedule.workout_name,
+                        "success": result is not None,
+                        "result": result,
+                    }
+                )
+                logger.info(
+                    f"Scheduled '{schedule.workout_name}' for {date_str} (user {self.user.id})"
+                )
+            except Exception as exc:
+                logger.error(
+                    f"Failed to schedule '{schedule.workout_name}' for {date_str}: {exc}",
+                    exc_info=True,
+                )
+                results.append(
+                    {
+                        "date": date_str,
+                        "schedule_id": schedule.id,
+                        "workout_name": schedule.workout_name,
+                        "success": False,
+                        "error": str(exc),
+                    }
+                )
+
+        return results
+
+    def apply_for_next_days(self, days: int = 30) -> List[Dict[str, Any]]:
+        """
+        Push active schedules for every day from today through the next N days (inclusive).
+
+        Garmin is connected once, then we pre-fetch each workout's already-scheduled
+        dates from Garmin so the loop can skip duplicates without extra API calls.
+
+        Returns a flat list of per-schedule/per-date result dicts:
+            {"date", "schedule_id", "workout_name", "success", "result"|"error"}
+        """
+        today = date.today()
+        end = today + timedelta(days=days - 1)
+
+        if not self.garmin_service.connect(self.user):
+            raise RuntimeError("Could not connect to Garmin Connect")
+
+        # Pre-fetch Garmin-side scheduled dates for every active workout, once.
+        # This catches manually-scheduled workouts that our local DB doesn't know about.
+        active_schedules = (
+            self.db.query(WorkoutSchedule)
+            .filter(
+                WorkoutSchedule.user_id == self.user.id,
+                WorkoutSchedule.is_active.is_(True),
+            )
+            .all()
+        )
+        unique_workout_ids = {s.workout_id for s in active_schedules}
+        garmin_scheduled: Dict[str, set] = {
+            wid: self.garmin_service.get_scheduled_dates_for_workout(wid)
+            for wid in unique_workout_ids
+        }
+        logger.info(
+            f"Pre-fetched Garmin schedule for {len(unique_workout_ids)} workout(s) "
+            f"(user {self.user.id})"
+        )
+
+        all_results: List[Dict[str, Any]] = []
+        current = today
+        while current <= end:
+            day_results = self._apply_date_connected(current, garmin_scheduled)
+            all_results.extend(day_results)
+            current += timedelta(days=1)
+
+        logger.info(
+            f"Next-{days}-days sync for user {self.user.id}: "
+            f"{len(all_results)} entries from {today} to {end}"
+        )
+        return all_results

--- a/backend/app/tasks/sync_tasks.py
+++ b/backend/app/tasks/sync_tasks.py
@@ -15,6 +15,14 @@ from app.services.garmin_to_strava_sync_service import GarminToStravaSyncService
 from app.services.strava_service import StravaService
 from app.services.sync_service import SyncService
 from app.services.weight_sync_service import WeightSyncService
+from app.utils.user_settings import (
+    KEY_LAST_GARMIN_POLL_AT,
+    KEY_LAST_STRAVA_POLL_AT,
+    get_garmin_to_strava_sync_enabled,
+    get_last_poll_at,
+    get_sync_schedule_minutes,
+    set_last_poll_at,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -121,11 +129,21 @@ def poll_strava_activities_task(self, lookback_days: int = 7, max_activities_per
     lookback_start = datetime.now(timezone.utc) - timedelta(days=lookback_days)
 
     users = self.db.query(User).filter(User.is_active == True).all()
+    now = datetime.now(timezone.utc)
 
     for user in users:
         # Only process users with both Strava and Garmin connected
         if not user.strava_auth or not user.garmin_auth:
             continue
+
+        # Skip if user's sync schedule interval has not elapsed since last poll
+        interval_minutes = get_sync_schedule_minutes(self.db, user.id)
+        last_at = get_last_poll_at(self.db, user.id, KEY_LAST_STRAVA_POLL_AT)
+        if last_at is not None and (last_at + timedelta(minutes=interval_minutes)) > now:
+            continue
+
+        set_last_poll_at(self.db, user.id, KEY_LAST_STRAVA_POLL_AT, now)
+        self.db.commit()
 
         try:
             strava_service = StravaService(self.db)
@@ -194,15 +212,24 @@ def poll_garmin_activities_task(self, lookback_days: int = 7, max_activities_per
     lookback_start = datetime.now(timezone.utc) - timedelta(days=lookback_days)
 
     users = self.db.query(User).filter(User.is_active == True).all()
+    now = datetime.now(timezone.utc)
 
     for user in users:
         # Only process users with both Strava and Garmin connected
         if not user.strava_auth or not user.garmin_auth:
             continue
 
-        from app.utils.user_settings import get_garmin_to_strava_sync_enabled
         if not get_garmin_to_strava_sync_enabled(user, self.db):
             continue
+
+        # Skip if user's sync schedule interval has not elapsed since last Garmin poll
+        interval_minutes = get_sync_schedule_minutes(self.db, user.id)
+        last_at = get_last_poll_at(self.db, user.id, KEY_LAST_GARMIN_POLL_AT)
+        if last_at is not None and (last_at + timedelta(minutes=interval_minutes)) > now:
+            continue
+
+        set_last_poll_at(self.db, user.id, KEY_LAST_GARMIN_POLL_AT, now)
+        self.db.commit()
 
         try:
             garmin_service = GarminService(self.db)
@@ -313,14 +340,14 @@ def poll_withings_weight_task(self):
     Periodically poll Withings for new weight measurements and sync to Garmin.
     """
     logger.info("Starting periodic Withings weight poll")
-    
+
     users = self.db.query(User).filter(User.is_active == True).all()
 
     for user in users:
         # Only process users with both Withings and Garmin connected
         if not user.withings_auth or not user.garmin_auth:
             continue
-            
+
         try:
             sync_service = WeightSyncService(self.db)
             sync_service.sync_weight(user)

--- a/backend/app/tasks/sync_tasks.py
+++ b/backend/app/tasks/sync_tasks.py
@@ -10,11 +10,13 @@ from celery import Task
 from app.celery_app import celery_app
 from app.database import SessionLocal
 from app.models import SyncLog, User
+from app.models.workout_schedule import WorkoutSchedule
 from app.services.garmin_service import GarminService
 from app.services.garmin_to_strava_sync_service import GarminToStravaSyncService
 from app.services.strava_service import StravaService
 from app.services.sync_service import SyncService
 from app.services.weight_sync_service import WeightSyncService
+from app.services.workout_schedule_service import WorkoutScheduleService
 from app.utils.user_settings import (
     KEY_LAST_GARMIN_POLL_AT,
     KEY_LAST_STRAVA_POLL_AT,
@@ -332,6 +334,52 @@ def poll_garmin_activities_task(self, lookback_days: int = 7, max_activities_per
 
         except Exception as e:
             logger.error(f"Error polling Garmin for user {user.id}: {e}", exc_info=True)
+
+
+@celery_app.task(bind=True, base=DatabaseTask)
+def apply_workout_schedules_task(self):
+    """
+    Daily task: push each user's active workout schedules whose weekday matches today to Garmin.
+    Runs once per day so workouts appear on the calendar without manual intervention.
+    """
+    from datetime import date
+
+    today = date.today()
+    day_of_week = today.weekday()  # 0=Mon … 6=Sun
+    logger.info(f"Applying workout schedules for {today.isoformat()} (weekday {day_of_week})")
+
+    # Find users who have at least one active schedule for today's weekday
+    schedules_today = (
+        self.db.query(WorkoutSchedule)
+        .filter(WorkoutSchedule.is_active.is_(True))
+        .all()
+    )
+    user_ids = {
+        s.user_id for s in schedules_today if day_of_week in (s.days_of_week or [])
+    }
+
+    if not user_ids:
+        logger.info("No active workout schedules match today — nothing to push")
+        return
+
+    users = self.db.query(User).filter(User.id.in_(user_ids), User.is_active == True).all()
+
+    for user in users:
+        if not user.garmin_auth:
+            continue
+        try:
+            svc = WorkoutScheduleService(self.db, user)
+            results = svc.apply_for_date(today)
+            success = sum(1 for r in results if r.get("success"))
+            failed = len(results) - success
+            logger.info(
+                f"Workout schedule task for user {user.id} on {today}: "
+                f"{success} succeeded, {failed} failed"
+            )
+        except Exception as exc:
+            logger.error(
+                f"Workout schedule task failed for user {user.id}: {exc}", exc_info=True
+            )
 
 
 @celery_app.task(bind=True, base=DatabaseTask)

--- a/backend/app/tasks/sync_tasks.py
+++ b/backend/app/tasks/sync_tasks.py
@@ -200,6 +200,10 @@ def poll_garmin_activities_task(self, lookback_days: int = 7, max_activities_per
         if not user.strava_auth or not user.garmin_auth:
             continue
 
+        from app.utils.user_settings import get_garmin_to_strava_sync_enabled
+        if not get_garmin_to_strava_sync_enabled(user, self.db):
+            continue
+
         try:
             garmin_service = GarminService(self.db)
             sync_service = GarminToStravaSyncService(self.db, user)

--- a/backend/app/utils/activity_converter.py
+++ b/backend/app/utils/activity_converter.py
@@ -210,6 +210,8 @@ class ActivityConverter:
         import logging
 
         logger = logging.getLogger(__name__)
+        if streams is None:
+            streams = {}
 
         # Helper function to convert Duration/timedelta to seconds
         def duration_to_seconds(duration):
@@ -252,23 +254,31 @@ class ActivityConverter:
         sport, sub_sport = ActivityConverter.map_activity_type_to_fit(activity_type_str)
         logger.info(f"Activity type: {activity_type_str} -> Sport: {sport}, SubSport: {sub_sport}")
 
-        # Extract stream data
-        latlng = streams.get("latlng").data if "latlng" in streams and streams.get("latlng") else []
+        # Extract stream data (latlng may be missing for indoor/manual activities)
+        latlng = []
+        if streams:
+            latlng = (
+                streams.get("latlng").data
+                if "latlng" in streams and streams.get("latlng")
+                else []
+            )
         altitude = (
             streams.get("altitude").data
-            if "altitude" in streams and streams.get("altitude")
+            if streams and "altitude" in streams and streams.get("altitude")
             else []
         )
         time_data_raw = (
-            streams.get("time").data if "time" in streams and streams.get("time") else []
+            streams.get("time").data if streams and "time" in streams and streams.get("time") else []
         )
         heartrate = (
             streams.get("heartrate").data
-            if "heartrate" in streams and streams.get("heartrate")
+            if streams and "heartrate" in streams and streams.get("heartrate")
             else []
         )
         cadence = (
-            streams.get("cadence").data if "cadence" in streams and streams.get("cadence") else []
+            streams.get("cadence").data
+            if streams and "cadence" in streams and streams.get("cadence")
+            else []
         )
 
         # Convert time data to seconds (might be int, float, or timedelta)
@@ -354,58 +364,99 @@ class ActivityConverter:
             records.append(record)
             builder.add(record)
 
-        # 3. Lap Message
+        # 2b. No GPS but we have time + HR/cadence: create record messages for stream data
+        if not records and (time_data or heartrate or cadence):
+            # Length: prefer time stream; else longest of HR/cadence; else 1 (lap/session only)
+            n_points = (
+                len(time_data)
+                if time_data
+                else max(
+                    len(heartrate) if heartrate else 0,
+                    len(cadence) if cadence else 0,
+                    1,
+                )
+            )
+            total_dist = (
+                float(activity.distance)
+                if hasattr(activity, "distance") and activity.distance
+                else None
+            )
+            for i in range(n_points):
+                record = RecordMessage()
+                if time_data and i < len(time_data):
+                    point_time = start_time + timedelta(seconds=time_data[i])
+                    record.timestamp = datetime_to_fit_timestamp(point_time)
+                else:
+                    point_time = start_time + timedelta(seconds=i)
+                    record.timestamp = datetime_to_fit_timestamp(point_time)
+                if i < len(heartrate):
+                    record.heart_rate = int(heartrate[i])
+                if i < len(cadence):
+                    record.cadence = int(cadence[i])
+                if total_dist is not None and n_points > 0:
+                    record.distance = total_dist * (i / n_points)
+                records.append(record)
+                builder.add(record)
+
+        # 3. Lap Message (required for Garmin; create from records or from activity summary)
+        lap = LapMessage()
         if records:
-            lap = LapMessage()
-            # timestamps are already in milliseconds from records
             lap.timestamp = (
                 records[-1].timestamp
                 if records[-1].timestamp
                 else datetime_to_fit_timestamp(start_time)
             )
-            lap.start_time = datetime_to_fit_timestamp(start_time)
-            lap.sport = sport
-            lap.sub_sport = sub_sport
-            logger.info(
-                f"Setting Lap: sport={sport} ({type(sport)}), sub_sport={sub_sport} ({type(sub_sport)})"
-            )
-            lap.total_elapsed_time = duration_to_seconds(activity.elapsed_time)
-            lap.total_timer_time = duration_to_seconds(activity.moving_time)
-            lap.total_distance = (
-                float(activity.distance)
-                if hasattr(activity, "distance") and activity.distance
-                else None
-            )
-            lap.total_calories = (
-                int(activity.calories)
-                if hasattr(activity, "calories") and activity.calories
-                else None
-            )
+        else:
+            # No GPS: use start_time + duration for end timestamp
+            elapsed = duration_to_seconds(activity.elapsed_time) or 0
+            end_time = start_time
+            if end_time.tzinfo is None:
+                end_time = end_time.replace(tzinfo=timezone.utc)
+            end_time = end_time + timedelta(seconds=elapsed)
+            lap.timestamp = datetime_to_fit_timestamp(end_time)
 
-            # Average/max heart rate
-            if heartrate:
-                lap.avg_heart_rate = int(sum(heartrate) / len(heartrate))
-                lap.max_heart_rate = int(max(heartrate))
+        lap.start_time = datetime_to_fit_timestamp(start_time)
+        lap.sport = sport
+        lap.sub_sport = sub_sport
+        logger.info(
+            f"Setting Lap: sport={sport} ({type(sport)}), sub_sport={sub_sport} ({type(sub_sport)})"
+        )
+        lap.total_elapsed_time = duration_to_seconds(activity.elapsed_time)
+        lap.total_timer_time = duration_to_seconds(activity.moving_time)
+        lap.total_distance = (
+            float(activity.distance)
+            if hasattr(activity, "distance") and activity.distance
+            else None
+        )
+        lap.total_calories = (
+            int(activity.calories)
+            if hasattr(activity, "calories") and activity.calories
+            else None
+        )
 
-            # Average/max cadence
-            if cadence:
-                lap.avg_cadence = int(sum(cadence) / len(cadence))
-                lap.max_cadence = int(max(cadence))
+        # Average/max heart rate
+        if heartrate:
+            lap.avg_heart_rate = int(sum(heartrate) / len(heartrate))
+            lap.max_heart_rate = int(max(heartrate))
 
-            # Elevation
-            if hasattr(activity, "total_elevation_gain") and activity.total_elevation_gain:
-                lap.total_ascent = int(activity.total_elevation_gain)
+        # Average/max cadence
+        if cadence:
+            lap.avg_cadence = int(sum(cadence) / len(cadence))
+            lap.max_cadence = int(max(cadence))
 
-            lap.lap_trigger = LapTrigger.SESSION_END
-            builder.add(lap)
+        # Elevation
+        if hasattr(activity, "total_elevation_gain") and activity.total_elevation_gain:
+            lap.total_ascent = int(activity.total_elevation_gain)
+
+        lap.lap_trigger = LapTrigger.SESSION_END
+        builder.add(lap)
 
         # 4. Session Message
         session = SessionMessage()
-        session.timestamp = (
-            records[-1].timestamp
-            if records and records[-1].timestamp
-            else datetime_to_fit_timestamp(start_time)
-        )
+        if records and records[-1].timestamp:
+            session.timestamp = records[-1].timestamp
+        else:
+            session.timestamp = lap.timestamp  # use same end time as lap (no-GPS case)
         session.start_time = datetime_to_fit_timestamp(start_time)
         session.sport = sport
         session.sub_sport = sub_sport

--- a/backend/app/utils/activity_converter.py
+++ b/backend/app/utils/activity_converter.py
@@ -10,18 +10,23 @@ import gpxpy
 import gpxpy.gpx
 from fit_tool.fit_file_builder import FitFileBuilder
 from fit_tool.profile.messages.activity_message import ActivityMessage
+from fit_tool.profile.messages.device_info_message import DeviceInfoMessage
+from fit_tool.profile.messages.event_message import EventMessage
 from fit_tool.profile.messages.file_id_message import FileIdMessage
 from fit_tool.profile.messages.lap_message import LapMessage
 from fit_tool.profile.messages.record_message import RecordMessage
 from fit_tool.profile.messages.session_message import SessionMessage
 from fit_tool.profile.profile_type import (
+    Activity,
     Event,
     EventType,
     FileType,
     LapTrigger,
     Manufacturer,
     Sport,
+    SourceType,
     SubSport,
+    TimerTrigger,
 )
 
 
@@ -196,13 +201,20 @@ class ActivityConverter:
         return type_mapping.get(strava_type, (Sport.GENERIC, SubSport.GENERIC))
 
     @staticmethod
-    def strava_to_fit(activity: Any, streams: Dict[str, Any]) -> bytes:
+    def strava_to_fit(
+        activity: Any,
+        streams: Dict[str, Any],
+        device_settings: Optional[Dict[str, Any]] = None,
+    ) -> bytes:
         """
         Convert Strava activity and streams to FIT format.
 
         Args:
             activity: Strava activity object
             streams: Dictionary of Stream objects from stravalib
+            device_settings: Optional dict from admin: device_name, serial_number,
+                manufacturer_id, software_version, product_id (strings). Maps to FIT product_name,
+                serial_number, manufacturer, software_version, product. Timestamp and device_index set on DeviceInfo.
 
         Returns:
             FIT data as bytes
@@ -212,6 +224,7 @@ class ActivityConverter:
         logger = logging.getLogger(__name__)
         if streams is None:
             streams = {}
+        device_settings = device_settings or {}
 
         # Helper function to convert Duration/timedelta to seconds
         def duration_to_seconds(duration):
@@ -247,6 +260,20 @@ class ActivityConverter:
             # Return Unix timestamp in MILLISECONDS
             return round(dt.timestamp() * 1000)
 
+        # FIT local_timestamp: seconds since 00:00 Dec 31, 1989 UTC (used for local time in Activity message)
+        _FIT_LOCAL_EPOCH = datetime(1989, 12, 31, 0, 0, 0, tzinfo=timezone.utc)
+
+        def datetime_to_fit_local_timestamp(dt):
+            """Convert datetime to FIT local_timestamp (seconds since 1989-12-31 00:00:00 UTC).
+            Use activity's local start time so the stored value displays as the timezone the
+            activity was in (e.g. Strava start_date_local); naive is treated as local-as-UTC
+            so viewers showing UTC display the correct local time."""
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            else:
+                dt = dt.astimezone(timezone.utc)
+            return int((dt - _FIT_LOCAL_EPOCH).total_seconds())
+
         # Extract activity type
         activity_type_str = (
             ActivityConverter.extract_activity_type(activity.type) if activity.type else "Ride"
@@ -258,9 +285,7 @@ class ActivityConverter:
         latlng = []
         if streams:
             latlng = (
-                streams.get("latlng").data
-                if "latlng" in streams and streams.get("latlng")
-                else []
+                streams.get("latlng").data if "latlng" in streams and streams.get("latlng") else []
             )
         altitude = (
             streams.get("altitude").data
@@ -268,7 +293,9 @@ class ActivityConverter:
             else []
         )
         time_data_raw = (
-            streams.get("time").data if streams and "time" in streams and streams.get("time") else []
+            streams.get("time").data
+            if streams and "time" in streams and streams.get("time")
+            else []
         )
         heartrate = (
             streams.get("heartrate").data
@@ -278,6 +305,16 @@ class ActivityConverter:
         cadence = (
             streams.get("cadence").data
             if streams and "cadence" in streams and streams.get("cadence")
+            else []
+        )
+        watts = (
+            streams.get("watts").data
+            if streams and "watts" in streams and streams.get("watts")
+            else []
+        )
+        velocity_smooth = (
+            streams.get("velocity_smooth").data
+            if streams and "velocity_smooth" in streams and streams.get("velocity_smooth")
             else []
         )
 
@@ -311,6 +348,20 @@ class ActivityConverter:
             f"start_time after conversion - type: {type(start_time)}, value: {start_time}, tzinfo: {start_time.tzinfo}"
         )
 
+        # start_date_local = activity start time in the activity's local timezone (Strava may send "Z" but it's local)
+        start_time_local = getattr(activity, "start_date_local", None)
+        if start_time_local is not None and not isinstance(start_time_local, datetime):
+            if isinstance(start_time_local, str):
+                from dateutil import parser as _parser
+
+                start_time_local = _parser.parse(start_time_local)
+            else:
+                start_time_local = None
+        if start_time_local is None:
+            start_time_local = start_time
+        elif start_time_local.tzinfo is not None:
+            start_time_local = start_time_local.replace(tzinfo=None)  # keep as naive local time
+
         # Test the timestamp conversion
         test_timestamp = datetime_to_fit_timestamp(start_time)
         logger.info(f"FIT timestamp (ms): {test_timestamp}")
@@ -318,13 +369,79 @@ class ActivityConverter:
         # Create FIT file builder
         builder = FitFileBuilder(auto_define=True, min_string_size=50)
 
-        # 1. File ID Message
+        # 1. File ID Message (optionally use admin device_settings)
         file_id = FileIdMessage()
         file_id.type = FileType.ACTIVITY
-        file_id.manufacturer = Manufacturer.STRAVA
-        file_id.product = 0
+        try:
+            m = device_settings.get("manufacturer_id")
+            file_id.manufacturer = (
+                int(m) if (m is not None and str(m).strip()) else Manufacturer.STRAVA
+            )
+            p = device_settings.get("product_id")
+            if p is not None and str(p).strip():
+                try:
+                    pv = int(str(p).strip())
+                    file_id.product = max(0, min(65535, pv))
+                except ValueError:
+                    file_id.product = 0
+            else:
+                file_id.product = 0
+            if device_settings.get("device_name"):
+                file_id.product_name = str(device_settings["device_name"]).strip()[:20]
+            s = device_settings.get("serial_number")
+            if s is not None and str(s).strip():
+                file_id.serial_number = int(s)
+        except (ValueError, TypeError):
+            file_id.manufacturer = Manufacturer.STRAVA
+            file_id.product = 0
         file_id.time_created = datetime_to_fit_timestamp(start_time)
         builder.add(file_id)
+
+        # 1a. Device Info Message (when device_settings provided; timestamp + device_index)
+        if device_settings:
+            try:
+                dev = DeviceInfoMessage()
+                dev.timestamp = datetime_to_fit_timestamp(start_time)
+                dev.device_index = 0
+                dev.source_type = SourceType.LOCAL  # 5 = local
+                if device_settings.get("device_name"):
+                    dev.product_name = str(device_settings["device_name"]).strip()[:20]
+                p = device_settings.get("product_id")
+                if p is not None and str(p).strip():
+                    try:
+                        pv = int(str(p).strip())
+                        dev.product = max(0, min(65535, pv))
+                    except ValueError:
+                        pass
+                s = device_settings.get("serial_number")
+                if s is not None and str(s).strip():
+                    dev.serial_number = int(s)
+                m = device_settings.get("manufacturer_id")
+                if m is not None and str(m).strip():
+                    dev.manufacturer = int(m)
+                sv = device_settings.get("software_version")
+                if sv is not None and str(sv).strip():
+                    # fit_tool DeviceInfo has software_version with scale=100: encoded = round(value * 100) as UINT16 [0, 65535].
+                    # Pass semantic version (e.g. 20.29); framework multiplies by 100. Max semantic value = 655.35.
+                    sv_str = str(sv).strip()
+                    try:
+                        val = float(sv_str)
+                        if 0 <= val <= 655.35:
+                            dev.software_version = val
+                    except (ValueError, TypeError):
+                        pass
+                builder.add(dev)
+            except (ValueError, TypeError):
+                pass
+
+        # 1b. Event: timer start at activity start time (data=manual)
+        timer_start_evt = EventMessage()
+        timer_start_evt.timestamp = datetime_to_fit_timestamp(start_time)
+        timer_start_evt.event = Event.TIMER
+        timer_start_evt.event_type = EventType.START
+        timer_start_evt.timer_trigger = TimerTrigger.MANUAL
+        timer_start_evt.event_group = 0
+        builder.add(timer_start_evt)
 
         # 2. Create Record Messages (GPS points)
         records = []
@@ -356,6 +473,14 @@ class ActivityConverter:
             if i < len(cadence):
                 record.cadence = int(cadence[i])
 
+            # Power (watts)
+            if i < len(watts):
+                record.power = int(watts[i])
+
+            # Speed (m/s, Strava velocity_smooth)
+            if i < len(velocity_smooth):
+                record.speed = float(velocity_smooth[i])
+
             # Distance (meters)
             if hasattr(activity, "distance") and activity.distance and len(latlng) > 0:
                 # Approximate distance based on position in stream
@@ -364,15 +489,16 @@ class ActivityConverter:
             records.append(record)
             builder.add(record)
 
-        # 2b. No GPS but we have time + HR/cadence: create record messages for stream data
-        if not records and (time_data or heartrate or cadence):
-            # Length: prefer time stream; else longest of HR/cadence; else 1 (lap/session only)
+        # 2b. No GPS but we have time + HR/cadence/watts/velocity_smooth: create record messages
+        if not records and (time_data or heartrate or cadence or watts or velocity_smooth):
             n_points = (
                 len(time_data)
                 if time_data
                 else max(
                     len(heartrate) if heartrate else 0,
                     len(cadence) if cadence else 0,
+                    len(watts) if watts else 0,
+                    len(velocity_smooth) if velocity_smooth else 0,
                     1,
                 )
             )
@@ -393,6 +519,10 @@ class ActivityConverter:
                     record.heart_rate = int(heartrate[i])
                 if i < len(cadence):
                     record.cadence = int(cadence[i])
+                if i < len(watts):
+                    record.power = int(watts[i])
+                if i < len(velocity_smooth):
+                    record.speed = float(velocity_smooth[i])
                 if total_dist is not None and n_points > 0:
                     record.distance = total_dist * (i / n_points)
                 records.append(record)
@@ -429,9 +559,7 @@ class ActivityConverter:
             else None
         )
         lap.total_calories = (
-            int(activity.calories)
-            if hasattr(activity, "calories") and activity.calories
-            else None
+            int(activity.calories) if hasattr(activity, "calories") and activity.calories else None
         )
 
         # Average/max heart rate
@@ -443,6 +571,11 @@ class ActivityConverter:
         if cadence:
             lap.avg_cadence = int(sum(cadence) / len(cadence))
             lap.max_cadence = int(max(cadence))
+
+        # Average/max power (watts)
+        if watts:
+            lap.avg_power = int(sum(watts) / len(watts))
+            lap.max_power = int(max(watts))
 
         # Elevation
         if hasattr(activity, "total_elevation_gain") and activity.total_elevation_gain:
@@ -484,20 +617,43 @@ class ActivityConverter:
             session.avg_cadence = int(sum(cadence) / len(cadence))
             session.max_cadence = int(max(cadence))
 
+        # Average/max power (watts)
+        if watts:
+            session.avg_power = int(sum(watts) / len(watts))
+            session.max_power = int(max(watts))
+
+        # Normalized power (Strava weighted_average_watts) when available
+        if hasattr(activity, "weighted_average_watts") and activity.weighted_average_watts:
+            session.normalized_power = int(activity.weighted_average_watts)
+
         # Elevation
         if hasattr(activity, "total_elevation_gain") and activity.total_elevation_gain:
             session.total_ascent = int(activity.total_elevation_gain)
 
         builder.add(session)
 
-        # 5. Activity Message
+        # 5. Activity Message: event=ACTIVITY, event_type=STOP (stop is on Activity, not a separate Event)
+        # local_timestamp = seconds since 1989-12-31 00:00:00 in local time (use start_date_local, no timezone field)
+        elapsed_secs = duration_to_seconds(activity.elapsed_time) or 0
+        end_time_utc = (
+            start_time if start_time.tzinfo else start_time.replace(tzinfo=timezone.utc)
+        ) + timedelta(seconds=elapsed_secs)
+        if start_time_local is not None:
+            # start_date_local is local time; end in local = start_local + elapsed
+            end_time_local_naive = start_time_local + timedelta(seconds=elapsed_secs)
+            epoch_local_naive = datetime(1989, 12, 31, 0, 0, 0)
+            local_ts = int((end_time_local_naive - epoch_local_naive).total_seconds())
+        else:
+            local_ts = datetime_to_fit_local_timestamp(end_time_utc)
+        local_ts = max(0, min(0xFFFFFFFF, local_ts))  # FIT local_timestamp is uint32
         activity_msg = ActivityMessage()
         activity_msg.timestamp = session.timestamp
         activity_msg.total_timer_time = session.total_timer_time
         activity_msg.num_sessions = 1
-        activity_msg.type = Event.ACTIVITY
+        activity_msg.type = Activity.AUTO_MULTI_SPORT
         activity_msg.event = Event.ACTIVITY
         activity_msg.event_type = EventType.STOP
+        activity_msg.local_timestamp = local_ts
         builder.add(activity_msg)
 
         # Build and return FIT file as bytes

--- a/backend/app/utils/file_storage.py
+++ b/backend/app/utils/file_storage.py
@@ -1,0 +1,99 @@
+"""
+File storage utilities for saving uploaded activity files.
+"""
+
+import os
+from pathlib import Path
+
+from app.config import settings
+
+# Default uploads directory (relative to backend root)
+DEFAULT_UPLOADS_DIR = "data/uploads"
+
+
+def get_uploads_directory() -> Path:
+    """
+    Get the uploads directory path, creating it if it doesn't exist.
+    
+    Returns:
+        Path object pointing to the uploads directory
+    """
+    # Use environment variable if set, otherwise use default
+    uploads_dir = os.getenv("UPLOADS_DIR", DEFAULT_UPLOADS_DIR)
+    
+    # If relative path, resolve relative to backend root (where this file is)
+    if not os.path.isabs(uploads_dir):
+        backend_root = Path(__file__).parent.parent.parent
+        uploads_path = backend_root / uploads_dir
+    else:
+        uploads_path = Path(uploads_dir)
+    
+    # Create directory if it doesn't exist
+    uploads_path.mkdir(parents=True, exist_ok=True)
+    
+    return uploads_path
+
+
+def save_uploaded_file(file_bytes: bytes, sync_log_id: int, extension: str) -> str:
+    """
+    Save uploaded file to disk and return the relative path.
+    
+    Args:
+        file_bytes: File content as bytes
+        sync_log_id: Sync log ID (used in filename)
+        extension: File extension (e.g., "fit", "gpx", "tcx")
+    
+    Returns:
+        Relative path to the saved file (relative to backend root)
+    """
+    uploads_dir = get_uploads_directory()
+    filename = f"sync_{sync_log_id}.{extension}"
+    file_path = uploads_dir / filename
+    
+    # Write file
+    with open(file_path, "wb") as f:
+        f.write(file_bytes)
+    
+    # Return relative path (for storage in DB)
+    backend_root = Path(__file__).parent.parent.parent
+    try:
+        relative_path = file_path.relative_to(backend_root)
+        return str(relative_path)
+    except ValueError:
+        # If not relative, return absolute path
+        return str(file_path)
+
+
+def get_file_path(stored_path: str) -> Path:
+    """
+    Get absolute Path object for a stored file path.
+    
+    Args:
+        stored_path: Path stored in database (relative or absolute)
+    
+    Returns:
+        Absolute Path object
+    """
+    path = Path(stored_path)
+    if path.is_absolute():
+        return path
+    
+    # If relative, resolve relative to backend root
+    backend_root = Path(__file__).parent.parent.parent
+    return backend_root / path
+
+
+def delete_uploaded_file(stored_path: str) -> None:
+    """
+    Delete an uploaded file from disk.
+    
+    Args:
+        stored_path: Path stored in database
+    """
+    try:
+        file_path = get_file_path(stored_path)
+        if file_path.exists():
+            file_path.unlink()
+    except Exception:
+        # Ignore errors when deleting (file might already be gone)
+        pass

--- a/backend/app/utils/fit_utils.py
+++ b/backend/app/utils/fit_utils.py
@@ -1,0 +1,32 @@
+"""
+FIT file utilities for GPS checks (e.g. before Strava upload).
+"""
+
+from pathlib import Path
+
+from fitparse import FitFile
+
+NO_GPS_MESSAGE = (
+    "This activity has no GPS data. Strava requires GPS for uploads; "
+    "indoor or manual activities cannot be synced to Strava."
+)
+
+
+def fit_file_has_gps(file_path: str) -> bool:
+    """
+    Check if a FIT file contains at least one record with GPS (position_lat/long).
+
+    Returns False if no GPS data; on parse error returns True so Strava can validate.
+    """
+    path = Path(file_path)
+    if not path.exists() or not path.is_file():
+        return True  # Let caller/Strava handle missing file
+    try:
+        fit = FitFile(str(path))
+        for record in fit.get_messages("record"):
+            for field in record:
+                if field.name in ("position_lat", "position_long") and field.value is not None:
+                    return True
+        return False
+    except Exception:
+        return True  # Parse error: allow upload, let Strava validate

--- a/backend/app/utils/user_settings.py
+++ b/backend/app/utils/user_settings.py
@@ -1,5 +1,9 @@
 """Helpers for user-specific settings (key-value store, override vs server default)."""
 
+import json
+from datetime import datetime, timezone
+from typing import Any
+
 from sqlalchemy.orm import Session
 
 from app.config import settings
@@ -8,17 +12,36 @@ from app.models import User, UserSettings
 # Setting keys (add new keys here when adding settings)
 KEY_GARMIN_TO_STRAVA_SYNC_DISABLED = "garmin_to_strava_sync_disabled"
 KEY_ALLOW_EXPORT_WITHOUT_GPS = "allow_export_without_gps"
+KEY_DISPLAY_TIMEZONE = "display_timezone"
+KEY_DISPLAY_TIME_FORMAT = "display_time_format"  # "12h" or "24h"
+KEY_SYNC_SCHEDULE_MINUTES = "sync_schedule_minutes"
+KEY_LAST_STRAVA_POLL_AT = "last_strava_poll_at"
+KEY_LAST_GARMIN_POLL_AT = "last_garmin_poll_at"
+KEY_FIT_DEVICE_SETTINGS = (
+    "fit_device_settings"  # JSON: device_name, serial_number, manufacturer_id, software_version
+)
+# Allowed sync schedule interval values (minutes)
+SYNC_SCHEDULE_CHOICES = (5, 10, 15, 30, 45, 60, 120, 240)
+DEFAULT_SYNC_SCHEDULE_MINUTES = 5
 
 
 def get_setting(db: Session, user_id: int, key: str) -> str | None:
     """Get raw string value for a key, or None if not set."""
-    row = db.query(UserSettings).filter(UserSettings.user_id == user_id, UserSettings.key == key).first()
+    row = (
+        db.query(UserSettings)
+        .filter(UserSettings.user_id == user_id, UserSettings.key == key)
+        .first()
+    )
     return row.value if row else None
 
 
 def set_setting(db: Session, user_id: int, key: str, value: str) -> None:
     """Set a key to a string value (upsert)."""
-    row = db.query(UserSettings).filter(UserSettings.user_id == user_id, UserSettings.key == key).first()
+    row = (
+        db.query(UserSettings)
+        .filter(UserSettings.user_id == user_id, UserSettings.key == key)
+        .first()
+    )
     if row:
         row.value = value
     else:
@@ -41,9 +64,93 @@ def get_allow_export_without_gps(user: User, db: Session) -> bool:
     return settings.ALLOW_EXPORT_WITHOUT_GPS
 
 
+def get_display_timezone(db: Session, user_id: int) -> str:
+    """Return display timezone for the user (for formatting dates). Default UTC."""
+    v = get_setting(db, user_id, KEY_DISPLAY_TIMEZONE)
+    return (v or "UTC").strip() or "UTC"
+
+
+def get_display_time_format(db: Session, user_id: int) -> str:
+    """Return display time format: '12h' or '24h'. Default 12h."""
+    v = get_setting(db, user_id, KEY_DISPLAY_TIME_FORMAT)
+    if v and v.strip().lower() in ("12h", "24h"):
+        return v.strip().lower()
+    return "12h"
+
+
 def get_setting_override_bool(db: Session, user_id: int, key: str) -> bool | None:
     """Get override as bool for API (True/False) or None if using server default."""
     v = get_setting(db, user_id, key)
     if v is None:
         return None
     return v == "true"
+
+
+def get_sync_schedule_minutes(db: Session, user_id: int) -> int:
+    """Return sync schedule interval in minutes. Default 5. One of SYNC_SCHEDULE_CHOICES."""
+    v = get_setting(db, user_id, KEY_SYNC_SCHEDULE_MINUTES)
+    if v is None:
+        return DEFAULT_SYNC_SCHEDULE_MINUTES
+    try:
+        n = int(v)
+        if n in SYNC_SCHEDULE_CHOICES:
+            return n
+    except ValueError:
+        pass
+    return DEFAULT_SYNC_SCHEDULE_MINUTES
+
+
+def get_last_poll_at(db: Session, user_id: int, key: str) -> datetime | None:
+    """Return last poll timestamp (UTC) from stored ISO string, or None."""
+    v = get_setting(db, user_id, key)
+    if not v or not v.strip():
+        return None
+    try:
+        return datetime.fromisoformat(v.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
+def set_last_poll_at(db: Session, user_id: int, key: str, when: datetime) -> None:
+    """Store poll timestamp as ISO string (UTC)."""
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    set_setting(db, user_id, key, when.isoformat())
+
+
+# FIT device settings (per-user, stored as JSON in UserSettings)
+FIT_DEVICE_KEYS = (
+    "device_name",
+    "serial_number",
+    "manufacturer_id",
+    "software_version",
+    "product_id",
+)
+
+
+def get_fit_device_settings(db: Session, user_id: int) -> dict[str, Any]:
+    """
+    Return FIT device settings for the user (device_name, serial_number, manufacturer_id, software_version, product_id).
+    Stored as JSON in UserSettings. Used when generating FIT files. Empty dict if not set.
+    """
+    v = get_setting(db, user_id, KEY_FIT_DEVICE_SETTINGS)
+    if not v or not v.strip():
+        return {}
+    try:
+        out = json.loads(v)
+        return out if isinstance(out, dict) else {}
+    except (json.JSONDecodeError, TypeError):
+        return {}
+
+
+def set_fit_device_settings(db: Session, user_id: int, data: dict[str, Any]) -> None:
+    """Store FIT device settings as JSON in UserSettings (device_name, serial_number, manufacturer_id, software_version, product_id)."""
+    clean = {}
+    for k, v in data.items():
+        if k not in FIT_DEVICE_KEYS or v is None:
+            continue
+        if isinstance(v, (int, float)):
+            clean[k] = str(v)
+        elif isinstance(v, str) and v.strip():
+            clean[k] = v.strip()
+    set_setting(db, user_id, KEY_FIT_DEVICE_SETTINGS, json.dumps(clean))

--- a/backend/app/utils/user_settings.py
+++ b/backend/app/utils/user_settings.py
@@ -1,0 +1,49 @@
+"""Helpers for user-specific settings (key-value store, override vs server default)."""
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models import User, UserSettings
+
+# Setting keys (add new keys here when adding settings)
+KEY_GARMIN_TO_STRAVA_SYNC_DISABLED = "garmin_to_strava_sync_disabled"
+KEY_ALLOW_EXPORT_WITHOUT_GPS = "allow_export_without_gps"
+
+
+def get_setting(db: Session, user_id: int, key: str) -> str | None:
+    """Get raw string value for a key, or None if not set."""
+    row = db.query(UserSettings).filter(UserSettings.user_id == user_id, UserSettings.key == key).first()
+    return row.value if row else None
+
+
+def set_setting(db: Session, user_id: int, key: str, value: str) -> None:
+    """Set a key to a string value (upsert)."""
+    row = db.query(UserSettings).filter(UserSettings.user_id == user_id, UserSettings.key == key).first()
+    if row:
+        row.value = value
+    else:
+        db.add(UserSettings(user_id=user_id, key=key, value=value))
+
+
+def get_garmin_to_strava_sync_enabled(user: User, db: Session) -> bool:
+    """Return effective Garmin→Strava sync enabled for this user (not disabled = enabled)."""
+    v = get_setting(db, user.id, KEY_GARMIN_TO_STRAVA_SYNC_DISABLED)
+    default_disabled = not settings.GARMIN_TO_STRAVA_SYNC_ENABLED
+    disabled = (v == "true") if v is not None else default_disabled
+    return not disabled
+
+
+def get_allow_export_without_gps(user: User, db: Session) -> bool:
+    """Return effective allow-export-without-GPS for this user (both directions)."""
+    v = get_setting(db, user.id, KEY_ALLOW_EXPORT_WITHOUT_GPS)
+    if v is not None:
+        return v == "true"
+    return settings.ALLOW_EXPORT_WITHOUT_GPS
+
+
+def get_setting_override_bool(db: Session, user_id: int, key: str) -> bool | None:
+    """Get override as bool for API (True/False) or None if using server default."""
+    v = get_setting(db, user_id, key)
+    if v is None:
+        return None
+    return v == "true"

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -3,6 +3,9 @@ set -e
 
 echo "Starting Strava-Garmin Sync Bridge backend..."
 
+# Migrations run automatically on every backend container start when DATABASE_URL is set.
+# This ensures new deployments and restarts always have the latest schema.
+
 # Extract database connection details from DATABASE_URL
 # Format: postgresql://user:password@host:port/dbname
 if [ -n "$DATABASE_URL" ]; then
@@ -29,8 +32,8 @@ if [ -n "$DATABASE_URL" ]; then
 
     echo "PostgreSQL is up - running database migrations..."
 
-    # Run database migrations
-    alembic upgrade head
+    # Run database migrations (must run from backend dir where alembic.ini lives)
+    cd /backend && alembic upgrade head
 
     echo "Migrations completed successfully!"
 else

--- a/backend/migrations/versions/193bece946bd_add_debug_fields_to_sync_logs.py
+++ b/backend/migrations/versions/193bece946bd_add_debug_fields_to_sync_logs.py
@@ -5,27 +5,29 @@ Revises: 0440a8a49743
 Create Date: 2025-11-20 22:14:17.763612
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
-
 # revision identifiers, used by Alembic.
-revision = '193bece946bd'
-down_revision = '0440a8a49743'
+revision = "193bece946bd"
+down_revision = "0440a8a49743"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
     # Add strava_data column (JSON type)
-    op.add_column('sync_logs', sa.Column('strava_data', postgresql.JSON(astext_type=sa.Text()), nullable=True))
+    op.add_column(
+        "sync_logs", sa.Column("strava_data", postgresql.JSON(astext_type=sa.Text()), nullable=True)
+    )
 
-    # Add gpx_data column (Text type)
-    op.add_column('sync_logs', sa.Column('gpx_data', sa.Text(), nullable=True))
+    # Add garmin_data column (Text type) - file summary or Garmin response data
+    op.add_column("sync_logs", sa.Column("garmin_data", sa.Text(), nullable=True))
 
 
 def downgrade() -> None:
     # Remove the added columns
-    op.drop_column('sync_logs', 'gpx_data')
-    op.drop_column('sync_logs', 'strava_data')
+    op.drop_column("sync_logs", "garmin_data")
+    op.drop_column("sync_logs", "strava_data")

--- a/backend/migrations/versions/a1b2c3d4e5f6_add_uploaded_file_fields_to_sync_logs.py
+++ b/backend/migrations/versions/a1b2c3d4e5f6_add_uploaded_file_fields_to_sync_logs.py
@@ -1,0 +1,34 @@
+"""add_uploaded_file_fields_to_sync_logs
+
+Revision ID: a1b2c3d4e5f6
+Revises: a5b6c7d8e9f0
+Create Date: 2026-01-31 12:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "a5b6c7d8e9f0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add uploaded_file_path column (String type) - stores path to file on filesystem
+    op.add_column(
+        "sync_logs", sa.Column("uploaded_file_path", sa.String(length=255), nullable=True)
+    )
+
+    # Add uploaded_file_extension column (String type)
+    op.add_column(
+        "sync_logs", sa.Column("uploaded_file_extension", sa.String(length=10), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    # Remove the added columns
+    op.drop_column("sync_logs", "uploaded_file_extension")
+    op.drop_column("sync_logs", "uploaded_file_path")

--- a/backend/migrations/versions/a5b6c7d8e9f0_add_user_display_name.py
+++ b/backend/migrations/versions/a5b6c7d8e9f0_add_user_display_name.py
@@ -1,0 +1,38 @@
+"""add user profile fields (username, first_name, last_name)
+
+Revision ID: a5b6c7d8e9f0
+Revises: f4e5a6b7c8d9
+Create Date: 2026-01-31
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "a5b6c7d8e9f0"
+down_revision = "f4e5a6b7c8d9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("username", sa.String(64), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("first_name", sa.String(255), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("last_name", sa.String(255), nullable=True),
+    )
+    op.create_index(op.f("ix_users_username"), "users", ["username"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_users_username"), table_name="users")
+    op.drop_column("users", "last_name")
+    op.drop_column("users", "first_name")
+    op.drop_column("users", "username")

--- a/backend/migrations/versions/e1f2a3b4c5d6_add_workout_schedules.py
+++ b/backend/migrations/versions/e1f2a3b4c5d6_add_workout_schedules.py
@@ -1,0 +1,39 @@
+"""add workout schedules
+
+Revision ID: e1f2a3b4c5d6
+Revises: b5f902b08422
+Create Date: 2026-04-03 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "e1f2a3b4c5d6"
+down_revision = "a1b2c3d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workout_schedules",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("workout_id", sa.String(), nullable=False),
+        sa.Column("workout_name", sa.String(), nullable=False),
+        sa.Column("days_of_week", sa.JSON(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_workout_schedules_id", "workout_schedules", ["id"], unique=False)
+    op.create_index("ix_workout_schedules_user_id", "workout_schedules", ["user_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_workout_schedules_user_id", table_name="workout_schedules")
+    op.drop_index("ix_workout_schedules_id", table_name="workout_schedules")
+    op.drop_table("workout_schedules")

--- a/backend/migrations/versions/f1g2h3i4j5k6_add_scheduled_workout_instances.py
+++ b/backend/migrations/versions/f1g2h3i4j5k6_add_scheduled_workout_instances.py
@@ -1,0 +1,64 @@
+"""add_scheduled_workout_instances
+
+Revision ID: f1g2h3i4j5k6
+Revises: e1f2a3b4c5d6
+Create Date: 2026-04-03 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "f1g2h3i4j5k6"
+down_revision = "e1f2a3b4c5d6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "scheduled_workout_instances",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("workout_id", sa.String(), nullable=False),
+        sa.Column("scheduled_date", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id", "workout_id", "scheduled_date", name="uq_user_workout_date"
+        ),
+    )
+    op.create_index(
+        op.f("ix_scheduled_workout_instances_id"),
+        "scheduled_workout_instances",
+        ["id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_scheduled_workout_instances_user_id"),
+        "scheduled_workout_instances",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_scheduled_workout_instances_scheduled_date"),
+        "scheduled_workout_instances",
+        ["scheduled_date"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_scheduled_workout_instances_scheduled_date"),
+        table_name="scheduled_workout_instances",
+    )
+    op.drop_index(
+        op.f("ix_scheduled_workout_instances_user_id"),
+        table_name="scheduled_workout_instances",
+    )
+    op.drop_index(
+        op.f("ix_scheduled_workout_instances_id"),
+        table_name="scheduled_workout_instances",
+    )
+    op.drop_table("scheduled_workout_instances")

--- a/backend/migrations/versions/f4e5a6b7c8d9_user_settings_table.py
+++ b/backend/migrations/versions/f4e5a6b7c8d9_user_settings_table.py
@@ -1,0 +1,39 @@
+"""user_settings table (key-value)
+
+Revision ID: f4e5a6b7c8d9
+Revises: c1826b108e86
+Create Date: 2026-01-31
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "f4e5a6b7c8d9"
+down_revision = "c1826b108e86"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_settings",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("key", sa.String(128), nullable=False),
+        sa.Column("value", sa.String(512), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "key", name="uq_user_settings_user_key"),
+    )
+    op.create_index(op.f("ix_user_settings_user_id"), "user_settings", ["user_id"], unique=False)
+    op.create_index(op.f("ix_user_settings_key"), "user_settings", ["key"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_user_settings_key"), table_name="user_settings")
+    op.drop_index(op.f("ix_user_settings_user_id"), table_name="user_settings")
+    op.drop_table("user_settings")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,7 +12,7 @@ psycopg2-binary==2.9.9
 stravalib>=2.0.0
 
 # Garmin Integration
-garminconnect==0.2.34
+garminconnect==0.2.38
 
 # Task Queue
 celery[redis]==5.3.4
@@ -27,7 +27,7 @@ cryptography==41.0.7
 # Activity File Handling
 fitparse==1.2.0
 gpxpy==1.6.2
-fit-tool==0.9.13
+fit-tool==0.9.14
 
 # HTTP Client
 httpx==0.25.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,7 +12,9 @@ psycopg2-binary==2.9.11
 stravalib>=2.0.0
 
 # Garmin Integration
-garminconnect==0.2.38
+garminconnect==0.3.1
+curl_cffi>=0.6
+ua-generator>=1.0
 
 # Task Queue
 celery[redis]==5.3.4

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,9 +4,9 @@ uvicorn[standard]==0.24.0
 python-multipart==0.0.6
 
 # Database
-sqlalchemy==2.0.23
+sqlalchemy==2.0.46
 alembic==1.12.1
-psycopg2-binary==2.9.9
+psycopg2-binary==2.9.11
 
 # Strava Integration
 stravalib>=2.0.0

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -86,7 +86,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 
 - **Removed from API responses**:
   - `session_data` (Garmin session tokens)
-  - `gpx_data` (raw location data)
+  - `garmin_data` (file summary or Garmin response data)
   - `strava_data` (may contain tokens)
   - Internal `user_id` (use JWT sub claim instead)
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -82,8 +82,9 @@ RDG3wCbonI_zTV0M6o9kIs8qe2jn8mL7JTDc05bxmQA=
 
 ## Step 4: Clone and Configure
 
-1. **Navigate to project directory**
+1. **Clone the repository and navigate to project directory**
 ```bash
+git clone <repo-url>
 cd strava-garmin-bridge
 ```
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@date-fns/tz": "^1.4.1",
         "@tanstack/react-query": "^5.90.10",
         "axios": "^1.13.2",
         "clsx": "^2.1.1",
@@ -517,6 +518,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "test:coverage": "vitest --coverage"
   },
   "dependencies": {
+    "@date-fns/tz": "^1.4.1",
     "@tanstack/react-query": "^5.90.10",
     "axios": "^1.13.2",
     "clsx": "^2.1.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import FiltersPage from './pages/FiltersPage';
 import SyncHistoryPage from './pages/SyncHistoryPage';
 import SettingsPage from './pages/SettingsPage';
 import ProfilePage from './pages/ProfilePage';
+import WorkoutSchedulePage from './pages/WorkoutSchedulePage';
 import Layout from './components/layout/Layout';
 
 const queryClient = new QueryClient({
@@ -22,8 +23,9 @@ const queryClient = new QueryClient({
 });
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated, isLoading, hasAuthToken } = useAuth();
+  const { authStatus, isLoading, hasAuthToken } = useAuth();
 
+  // No JWT at all → must log in
   if (!hasAuthToken) {
     return <Navigate to="/auth" replace />;
   }
@@ -39,7 +41,8 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
     );
   }
 
-  if (!isAuthenticated) {
+  // Strava not connected → need initial setup (Garmin issues don't kick users out)
+  if (authStatus && !authStatus.strava_connected) {
     return <Navigate to="/auth" replace />;
   }
 
@@ -65,6 +68,7 @@ function AppRoutes() {
         <Route path="history" element={<SyncHistoryPage />} />
         <Route path="settings" element={<SettingsPage />} />
         <Route path="profile" element={<ProfilePage />} />
+        <Route path="workouts" element={<WorkoutSchedulePage />} />
       </Route>
     </Routes>
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,8 @@ import WithingsCallbackPage from './pages/WithingsCallbackPage';
 import DashboardPage from './pages/DashboardPage';
 import FiltersPage from './pages/FiltersPage';
 import SyncHistoryPage from './pages/SyncHistoryPage';
+import SettingsPage from './pages/SettingsPage';
+import ProfilePage from './pages/ProfilePage';
 import Layout from './components/layout/Layout';
 
 const queryClient = new QueryClient({
@@ -61,6 +63,8 @@ function AppRoutes() {
         <Route index element={<DashboardPage />} />
         <Route path="filters" element={<FiltersPage />} />
         <Route path="history" element={<SyncHistoryPage />} />
+        <Route path="settings" element={<SettingsPage />} />
+        <Route path="profile" element={<ProfilePage />} />
       </Route>
     </Routes>
   );

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,5 +1,5 @@
 import { apiClient } from './client';
-import type { AuthStatus, GarminCredentials, StravaAuthResponse, StravaAuthUrlResponse, WithingsAuthResponse, WithingsAuthUrlResponse } from '../types';
+import type { AuthStatus, GarminCredentials, GarminCredentialsResponse, ProfileUpdate, SettingsUpdate, StravaAuthResponse, StravaAuthUrlResponse, UserSettings, WithingsAuthResponse, WithingsAuthUrlResponse } from '../types';
 
 export const authApi = {
   /**
@@ -159,10 +159,25 @@ export const authApi = {
   },
 
   /**
-   * Save Garmin credentials (requires authentication)
+   * Save Garmin credentials (requires authentication).
+   * If account has MFA, returns mfa_required and mfa_token; call submitGarminMfa with the code.
    */
   saveGarminCredentials: async (credentials: GarminCredentials) => {
-    const response = await apiClient.post('/api/v1/auth/garmin/credentials', credentials);
+    const response = await apiClient.post<GarminCredentialsResponse>(
+      '/api/v1/auth/garmin/credentials',
+      credentials
+    );
+    return response.data;
+  },
+
+  /**
+   * Complete Garmin login with MFA code (after credentials returned mfa_required).
+   */
+  submitGarminMfa: async (mfaToken: string, mfaCode: string) => {
+    const response = await apiClient.post('/api/v1/auth/garmin/mfa', {
+      mfa_token: mfaToken,
+      mfa_code: mfaCode,
+    });
     return response.data;
   },
 
@@ -171,6 +186,30 @@ export const authApi = {
    */
   getAuthStatus: async (): Promise<AuthStatus> => {
     const response = await apiClient.get<AuthStatus>('/api/v1/auth/status');
+    return response.data;
+  },
+
+  /**
+   * Get user settings (for Settings tab)
+   */
+  getSettings: async (): Promise<UserSettings> => {
+    const response = await apiClient.get<UserSettings>('/api/v1/auth/settings');
+    return response.data;
+  },
+
+  /**
+   * Update user settings
+   */
+  updateSettings: async (data: SettingsUpdate): Promise<UserSettings> => {
+    const response = await apiClient.patch<UserSettings>('/api/v1/auth/settings', data);
+    return response.data;
+  },
+
+  /**
+   * Update profile (email, display name)
+   */
+  updateProfile: async (data: ProfileUpdate): Promise<{ email: string; username: string | null; first_name: string | null; last_name: string | null }> => {
+    const response = await apiClient.patch<{ email: string; username: string | null; first_name: string | null; last_name: string | null }>('/api/v1/auth/profile', data);
     return response.data;
   },
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,5 +1,5 @@
 import { apiClient } from './client';
-import type { AuthStatus, GarminCredentials, GarminCredentialsResponse, ProfileUpdate, SettingsUpdate, StravaAuthResponse, StravaAuthUrlResponse, UserSettings, WithingsAuthResponse, WithingsAuthUrlResponse } from '../types';
+import type { AuthStatus, GarminCredentials, GarminCredentialsResponse, ProfileUpdate, SettingsUpdate, StravaAuthResponse, StravaAuthUrlResponse, UserSettings, WithingsAuthResponse, WithingsAuthUrlResponse } from '../types/auth';
 
 export const authApi = {
   /**
@@ -206,10 +206,10 @@ export const authApi = {
   },
 
   /**
-   * Update profile (email, display name)
+   * Update profile (email, display name, display_timezone)
    */
-  updateProfile: async (data: ProfileUpdate): Promise<{ email: string; username: string | null; first_name: string | null; last_name: string | null }> => {
-    const response = await apiClient.patch<{ email: string; username: string | null; first_name: string | null; last_name: string | null }>('/api/v1/auth/profile', data);
+  updateProfile: async (data: ProfileUpdate): Promise<{ email: string; username: string | null; first_name: string | null; last_name: string | null; display_timezone: string; display_time_format: string }> => {
+    const response = await apiClient.patch<{ email: string; username: string | null; first_name: string | null; last_name: string | null; display_timezone: string; display_time_format: string }>('/api/v1/auth/profile', data);
     return response.data;
   },
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -26,11 +26,18 @@ apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.status === 401) {
-      // Clear token and redirect to auth
-      localStorage.removeItem('auth_token');
-      localStorage.removeItem('user_email');
-      localStorage.removeItem('athlete_id');
-      window.location.href = '/auth';
+      const url: string = error.config?.url ?? '';
+      // Garmin/Withings credential endpoints return 401 for bad third-party credentials,
+      // NOT because the app session is invalid. Don't log the user out for those.
+      const isThirdPartyCredentialEndpoint =
+        url.includes('/auth/garmin/') || url.includes('/auth/withings/');
+
+      if (!isThirdPartyCredentialEndpoint) {
+        localStorage.removeItem('auth_token');
+        localStorage.removeItem('user_email');
+        localStorage.removeItem('athlete_id');
+        window.location.href = '/auth';
+      }
     }
     return Promise.reject(error);
   }

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -3,3 +3,4 @@ export * from './auth';
 export * from './filters';
 export * from './sync';
 export * from './activities';
+export { workoutsApi } from './workouts';

--- a/frontend/src/api/sync.ts
+++ b/frontend/src/api/sync.ts
@@ -78,4 +78,20 @@ export const syncApi = {
     const response = await apiClient.get(`/api/v1/sync/history/${syncLogId}/details`);
     return response.data;
   },
+
+  /**
+   * Download FIT file for a successful sync log. Triggers a file download in the browser.
+   */
+  downloadFit: async (syncLogId: number, sourceActivityId: string): Promise<void> => {
+    const response = await apiClient.get(`/api/v1/sync/history/${syncLogId}/download-fit`, { responseType: 'blob' });
+    const blob = response.data as Blob;
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `activity-${sourceActivityId}.fit`;
+    document.body.appendChild(a);
+    a.click();
+    window.URL.revokeObjectURL(url);
+    document.body.removeChild(a);
+  },
 };

--- a/frontend/src/api/sync.ts
+++ b/frontend/src/api/sync.ts
@@ -1,5 +1,5 @@
 import { apiClient } from './client';
-import type { SyncLog, SyncStats, ManualSyncRequest, ManualSyncResponse } from '../types';
+import type { SyncLog, SyncStats, ManualSyncRequest, ManualSyncResponse, SyncLogDetails, BulkDeleteSyncLogsParams } from '../types';
 
 export const syncApi = {
   /**
@@ -66,11 +66,7 @@ export const syncApi = {
   /**
    * Bulk delete sync logs with optional filters
    */
-  bulkDeleteSyncLogs: async (params?: {
-    status?: 'success' | 'failed' | 'skipped' | 'pending';
-    before_date?: string;
-    strava_activity_id?: string;
-  }): Promise<{ message: string; deleted_count: number }> => {
+  bulkDeleteSyncLogs: async (params?: BulkDeleteSyncLogsParams): Promise<{ message: string; deleted_count: number }> => {
     const response = await apiClient.delete('/api/v1/sync/history', { params });
     return response.data;
   },
@@ -78,22 +74,7 @@ export const syncApi = {
   /**
    * Get sync log details including debug data
    */
-  getSyncLogDetails: async (syncLogId: number): Promise<{
-    id: number;
-    sync_direction: string;
-    source_activity_id: string;
-    target_activity_id: string | null;
-    strava_activity_id: string;  // Legacy field
-    garmin_activity_id: string | null;  // Legacy field
-    status: string;
-    error_message: string | null;
-    activity_name: string | null;
-    activity_type: string | null;
-    strava_data: any | null;
-    gpx_data: string | null;
-    created_at: string;
-    completed_at: string | null;
-  }> => {
+  getSyncLogDetails: async (syncLogId: number): Promise<SyncLogDetails> => {
     const response = await apiClient.get(`/api/v1/sync/history/${syncLogId}/details`);
     return response.data;
   },

--- a/frontend/src/api/workouts.ts
+++ b/frontend/src/api/workouts.ts
@@ -1,0 +1,54 @@
+import { apiClient } from './client';
+import type {
+  GarminWorkout,
+  WorkoutSchedule,
+  CreateScheduleRequest,
+  SyncSchedulesRequest,
+  SyncSchedulesResponse,
+  SyncMonthRequest,
+  SyncMonthResponse,
+} from '../types';
+
+export const workoutsApi = {
+  /** Fetch the user's Garmin workout library. */
+  listLibrary: async (): Promise<GarminWorkout[]> => {
+    const response = await apiClient.get('/api/v1/workouts/library');
+    return response.data;
+  },
+
+  /** List all saved recurring schedules. */
+  listSchedules: async (): Promise<WorkoutSchedule[]> => {
+    const response = await apiClient.get('/api/v1/workouts/schedules');
+    return response.data;
+  },
+
+  /** Create a new recurring schedule. */
+  createSchedule: async (data: CreateScheduleRequest): Promise<WorkoutSchedule> => {
+    const response = await apiClient.post('/api/v1/workouts/schedules', data);
+    return response.data;
+  },
+
+  /** Enable or disable a schedule. */
+  toggleSchedule: async (id: number, is_active: boolean): Promise<WorkoutSchedule> => {
+    const response = await apiClient.patch(`/api/v1/workouts/schedules/${id}`, { is_active });
+    return response.data;
+  },
+
+  /** Delete a schedule. */
+  deleteSchedule: async (id: number): Promise<{ message: string }> => {
+    const response = await apiClient.delete(`/api/v1/workouts/schedules/${id}`);
+    return response.data;
+  },
+
+  /** Manually push today's (or a specific date's) scheduled workouts to Garmin. */
+  syncSchedules: async (data?: SyncSchedulesRequest): Promise<SyncSchedulesResponse> => {
+    const response = await apiClient.post('/api/v1/workouts/schedules/sync', data ?? {});
+    return response.data;
+  },
+
+  /** Push all active schedules for every remaining day of the given month to Garmin. */
+  syncMonth: async (data?: SyncMonthRequest): Promise<SyncMonthResponse> => {
+    const response = await apiClient.post('/api/v1/workouts/schedules/sync-month', data ?? {});
+    return response.data;
+  },
+};

--- a/frontend/src/components/ActivitiesList.tsx
+++ b/frontend/src/components/ActivitiesList.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import type { Activity } from '../api/activities';
 import { activitiesApi } from '../api/activities';
 import { syncApi } from '../api/sync';
+import { useAuth } from '../hooks/useAuth';
 import { toast } from 'sonner';
 
 interface ActivitiesListProps {
@@ -9,6 +10,9 @@ interface ActivitiesListProps {
 }
 
 export function ActivitiesList({ limit = 10 }: ActivitiesListProps) {
+  const { authStatus } = useAuth();
+  const garminToStravaEnabled = authStatus?.garmin_to_strava_sync_disabled !== true;
+
   const [activities, setActivities] = useState<Activity[]>([]);
   const [loading, setLoading] = useState(true);
   const [activeSource, setActiveSource] = useState<'all' | 'strava' | 'garmin'>('all');
@@ -129,8 +133,9 @@ export function ActivitiesList({ limit = 10 }: ActivitiesListProps) {
           <h2 className="text-lg font-semibold">Recent Activities</h2>
           <div className="flex gap-2 overflow-x-auto pb-2 sm:pb-0">
             <button
+              type="button"
               onClick={() => setActiveSource('all')}
-              className={`px-3 py-1.5 text-sm font-medium rounded-md whitespace-nowrap transition-colors ${
+              className={`px-3 py-1.5 text-sm font-medium rounded-md whitespace-nowrap transition-colors cursor-pointer ${
                 activeSource === 'all'
                   ? 'bg-primary text-white'
                   : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
@@ -139,8 +144,9 @@ export function ActivitiesList({ limit = 10 }: ActivitiesListProps) {
               All
             </button>
             <button
+              type="button"
               onClick={() => setActiveSource('strava')}
-              className={`px-3 py-1.5 text-sm font-medium rounded-md whitespace-nowrap transition-colors ${
+              className={`px-3 py-1.5 text-sm font-medium rounded-md whitespace-nowrap transition-colors cursor-pointer ${
                 activeSource === 'strava'
                   ? 'bg-primary text-white'
                   : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
@@ -149,8 +155,9 @@ export function ActivitiesList({ limit = 10 }: ActivitiesListProps) {
               Strava
             </button>
             <button
+              type="button"
               onClick={() => setActiveSource('garmin')}
-              className={`px-3 py-1.5 text-sm font-medium rounded-md whitespace-nowrap transition-colors ${
+              className={`px-3 py-1.5 text-sm font-medium rounded-md whitespace-nowrap transition-colors cursor-pointer ${
                 activeSource === 'garmin'
                   ? 'bg-primary text-white'
                   : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
@@ -242,11 +249,11 @@ export function ActivitiesList({ limit = 10 }: ActivitiesListProps) {
                       </div>
                     )}
                   </div>
-                  {!activity.synced && (
+                  {!activity.synced && (activity.source === 'strava' || garminToStravaEnabled) && (
                     <button
                       onClick={() => handleSync(activity)}
                       disabled={syncingActivityId === activity.id}
-                      className="px-3 py-1.5 text-sm font-medium text-white bg-primary hover:bg-primary/90 rounded-md disabled:opacity-50 whitespace-nowrap transition-colors"
+                      className="px-3 py-1.5 text-sm font-medium text-white bg-primary hover:bg-primary/90 rounded-md disabled:opacity-50 whitespace-nowrap transition-colors cursor-pointer"
                       title={activity.source === 'strava' ? 'Sync to Garmin' : 'Sync to Strava'}
                     >
                       {syncingActivityId === activity.id ? (

--- a/frontend/src/components/ActivitiesList.tsx
+++ b/frontend/src/components/ActivitiesList.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import type { Activity } from '../api/activities';
 import { activitiesApi } from '../api/activities';
 import { syncApi } from '../api/sync';
@@ -12,6 +13,7 @@ interface ActivitiesListProps {
 
 export function ActivitiesList({ limit = 10 }: ActivitiesListProps) {
   const { authStatus } = useAuth();
+  const navigate = useNavigate();
   const garminToStravaEnabled = authStatus?.garmin_to_strava_sync_disabled !== true;
   const displayTimezone = authStatus?.display_timezone ?? 'UTC';
   const hour12 = authStatus?.display_time_format !== '24h';
@@ -20,6 +22,7 @@ export function ActivitiesList({ limit = 10 }: ActivitiesListProps) {
   const [loading, setLoading] = useState(true);
   const [activeSource, setActiveSource] = useState<'all' | 'strava' | 'garmin'>('all');
   const [syncingActivityId, setSyncingActivityId] = useState<string | null>(null);
+  const [sourceErrors, setSourceErrors] = useState<{ strava?: string; garmin?: string }>({});
 
   useEffect(() => {
     loadActivities();
@@ -27,11 +30,26 @@ export function ActivitiesList({ limit = 10 }: ActivitiesListProps) {
 
   const loadActivities = async () => {
     setLoading(true);
+    setSourceErrors({});
     try {
+      const errors: { strava?: string; garmin?: string } = {};
+
       const [stravaActivities, garminActivities] = await Promise.all([
-        activitiesApi.getStravaActivities(limit).catch(() => []),
-        activitiesApi.getGarminActivities(limit).catch(() => []),
+        activitiesApi.getStravaActivities(limit).catch((err: any) => {
+          const detail = err?.response?.data?.detail || 'Failed to load Strava activities';
+          errors.strava = detail;
+          return [] as Activity[];
+        }),
+        activitiesApi.getGarminActivities(limit).catch((err: any) => {
+          const detail = err?.response?.data?.detail || 'Failed to load Garmin activities';
+          errors.garmin = detail;
+          return [] as Activity[];
+        }),
       ]);
+
+      if (Object.keys(errors).length > 0) {
+        setSourceErrors(errors);
+      }
 
       // Combine and sort by date (most recent first)
       const combined = [...stravaActivities, ...garminActivities].sort(
@@ -155,9 +173,35 @@ export function ActivitiesList({ limit = 10 }: ActivitiesListProps) {
         </div>
       </div>
 
+      {(sourceErrors.strava || sourceErrors.garmin) && (
+        <div className="px-4 sm:px-6 py-3 bg-amber-50 border-b border-amber-100 space-y-2">
+          {sourceErrors.strava && (
+            <p className="text-sm text-amber-700">
+              <span className="font-medium">Strava:</span> {sourceErrors.strava}
+            </p>
+          )}
+          {sourceErrors.garmin && (
+            <div className="flex flex-wrap items-center gap-3">
+              <p className="text-sm text-amber-700">
+                <span className="font-medium">Garmin:</span> {sourceErrors.garmin}
+              </p>
+              <button
+                type="button"
+                onClick={() => navigate('/settings')}
+                className="text-xs font-medium text-white bg-amber-600 hover:bg-amber-700 px-2.5 py-1 rounded cursor-pointer whitespace-nowrap"
+              >
+                Re-authenticate →
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
       {filteredActivities.length === 0 ? (
         <div className="p-8 text-center text-gray-500">
-          No activities found
+          {sourceErrors.strava && sourceErrors.garmin
+            ? 'Could not load activities from either source.'
+            : 'No activities found'}
         </div>
       ) : (
         <div className="divide-y">

--- a/frontend/src/components/ActivitiesList.tsx
+++ b/frontend/src/components/ActivitiesList.tsx
@@ -3,6 +3,7 @@ import type { Activity } from '../api/activities';
 import { activitiesApi } from '../api/activities';
 import { syncApi } from '../api/sync';
 import { useAuth } from '../hooks/useAuth';
+import { formatDateOnly, formatTime } from '../lib/utils';
 import { toast } from 'sonner';
 
 interface ActivitiesListProps {
@@ -12,6 +13,8 @@ interface ActivitiesListProps {
 export function ActivitiesList({ limit = 10 }: ActivitiesListProps) {
   const { authStatus } = useAuth();
   const garminToStravaEnabled = authStatus?.garmin_to_strava_sync_disabled !== true;
+  const displayTimezone = authStatus?.display_timezone ?? 'UTC';
+  const hour12 = authStatus?.display_time_format !== '24h';
 
   const [activities, setActivities] = useState<Activity[]>([]);
   const [loading, setLoading] = useState(true);
@@ -58,23 +61,6 @@ export function ActivitiesList({ limit = 10 }: ActivitiesListProps) {
       return `${hours}h ${minutes}m`;
     }
     return `${minutes}m`;
-  };
-
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
-  };
-
-  const formatTime = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleTimeString('en-US', {
-      hour: '2-digit',
-      minute: '2-digit',
-    });
   };
 
   const handleSync = async (activity: Activity) => {
@@ -212,7 +198,7 @@ export function ActivitiesList({ limit = 10 }: ActivitiesListProps) {
                           d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
                         />
                       </svg>
-                      {formatDate(activity.start_date)}
+                      {formatDateOnly(activity.start_date, displayTimezone)}
                     </span>
                     <span className="flex items-center gap-1">
                       <svg
@@ -228,7 +214,7 @@ export function ActivitiesList({ limit = 10 }: ActivitiesListProps) {
                           d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
                         />
                       </svg>
-                      {formatTime(activity.start_date)}
+                      {formatTime(activity.start_date, displayTimezone, hour12)}
                     </span>
                   </div>
                 </div>

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { Outlet, Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../../hooks/useAuth';
 
@@ -6,11 +6,24 @@ export default function Layout() {
   const location = useLocation();
   const { authStatus, logout } = useAuth();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [profileMenuOpen, setProfileMenuOpen] = useState(false);
+  const profileMenuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (profileMenuRef.current && !profileMenuRef.current.contains(event.target as Node)) {
+        setProfileMenuOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
 
   const navItems = [
     { path: '/', label: 'Dashboard' },
     { path: '/filters', label: 'Filters' },
     { path: '/history', label: 'History' },
+    { path: '/settings', label: 'Settings' },
   ];
 
   return (
@@ -43,15 +56,45 @@ export default function Layout() {
             </div>
             <div className="flex items-center">
               <div className="hidden sm:flex sm:items-center sm:space-x-4">
-                <div className="text-sm">
-                  <p className="text-gray-700 truncate max-w-[200px]">{authStatus?.email}</p>
+                <div className="relative" ref={profileMenuRef}>
+                  <button
+                    type="button"
+                    onClick={() => setProfileMenuOpen(!profileMenuOpen)}
+                    className="flex items-center gap-1 text-sm text-gray-700 hover:text-gray-900 focus:outline-none cursor-pointer"
+                    aria-expanded={profileMenuOpen}
+                    aria-haspopup="true"
+                  >
+                    <span className="truncate max-w-[200px]">
+                      {authStatus?.username ||
+                        [authStatus?.first_name, authStatus?.last_name].filter(Boolean).join(' ') ||
+                        authStatus?.email}
+                    </span>
+                    <svg className="w-4 h-4 shrink-0 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </button>
+                  {profileMenuOpen && (
+                    <div className="absolute right-0 z-10 mt-1 w-48 rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5">
+                      <Link
+                        to="/profile"
+                        onClick={() => setProfileMenuOpen(false)}
+                        className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                      >
+                        Profile
+                      </Link>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setProfileMenuOpen(false);
+                          logout();
+                        }}
+                        className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer"
+                      >
+                        Logout
+                      </button>
+                    </div>
+                  )}
                 </div>
-                <button
-                  onClick={logout}
-                  className="text-sm text-gray-500 hover:text-gray-700 whitespace-nowrap"
-                >
-                  Logout
-                </button>
               </div>
               <div className="sm:hidden flex items-center">
                 <button
@@ -96,16 +139,27 @@ export default function Layout() {
             <div className="pt-4 pb-3 border-t border-gray-200">
               <div className="flex items-center px-4 mb-3">
                 <div className="text-sm">
-                  <p className="text-gray-700 font-medium">{authStatus?.email}</p>
+                  <p className="text-gray-700 font-medium">
+                  {authStatus?.username ||
+                    [authStatus?.first_name, authStatus?.last_name].filter(Boolean).join(' ') ||
+                    authStatus?.email}
+                </p>
                 </div>
               </div>
-              <div className="px-4">
+              <div className="px-4 space-y-1">
+                <Link
+                  to="/profile"
+                  onClick={() => setMobileMenuOpen(false)}
+                  className="block text-base font-medium text-gray-500 hover:text-gray-700"
+                >
+                  Profile
+                </Link>
                 <button
                   onClick={() => {
                     logout();
                     setMobileMenuOpen(false);
                   }}
-                  className="w-full text-left text-base font-medium text-gray-500 hover:text-gray-700"
+                  className="w-full text-left text-base font-medium text-gray-500 hover:text-gray-700 cursor-pointer"
                 >
                   Logout
                 </button>

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -23,6 +23,7 @@ export default function Layout() {
     { path: '/', label: 'Dashboard' },
     { path: '/filters', label: 'Filters' },
     { path: '/history', label: 'History' },
+    { path: '/workouts', label: 'Workouts' },
     { path: '/settings', label: 'Settings' },
   ];
 

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -17,6 +17,16 @@ export function useAuth() {
 
   const saveGarminMutation = useMutation({
     mutationFn: authApi.saveGarminCredentials,
+    onSuccess: (data) => {
+      if (!data?.mfa_required) {
+        queryClient.invalidateQueries({ queryKey: QUERY_KEYS.authStatus });
+      }
+    },
+  });
+
+  const submitGarminMfaMutation = useMutation({
+    mutationFn: ({ mfaToken, mfaCode }: { mfaToken: string; mfaCode: string }) =>
+      authApi.submitGarminMfa(mfaToken, mfaCode),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.authStatus });
     },
@@ -44,12 +54,21 @@ export function useAuth() {
     return saveGarminMutation.mutateAsync(credentials);
   };
 
+  const submitGarminMfa = async (mfaToken: string, mfaCode: string) => {
+    return submitGarminMfaMutation.mutateAsync({ mfaToken, mfaCode });
+  };
+
   const logout = () => {
     authApi.logout();
   };
 
+  const refetchAuthStatus = () => {
+    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.authStatus });
+  };
+
   return {
     authStatus,
+    refetchAuthStatus,
     isLoading,
     error,
     isAuthenticated: !!(authStatus?.strava_connected && authStatus?.garmin_connected),
@@ -57,8 +76,10 @@ export function useAuth() {
     connectStrava,
     connectWithings,
     saveGarminCredentials,
+    submitGarminMfa,
     logout,
     isSavingGarmin: saveGarminMutation.isPending,
-    garminError: saveGarminMutation.error,
+    isSubmittingGarminMfa: submitGarminMfaMutation.isPending,
+    garminError: saveGarminMutation.error ?? submitGarminMfaMutation.error,
   };
 }

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,29 +1,86 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
+import { format } from "date-fns";
+import { TZDate } from "@date-fns/tz";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export function formatDate(date: string): string {
-  return new Date(date).toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+const DEFAULT_TZ = "UTC";
+
+/**
+ * Parse API date string as UTC when it has no timezone (backend sends naive UTC).
+ * Returns ISO string with Z for use with TZDate.
+ */
+function toUtcIso(date: string): string {
+  const s = typeof date === "string" ? date.trim() : "";
+  if (!s) return "";
+  if (/[Zz]$/.test(s) || /[+-]\d{2}:?\d{2}$/.test(s)) return s;
+  return s + "Z";
 }
 
-export function formatRelativeTime(date: string): string {
+/**
+ * Get a TZDate for the given UTC moment in the given timezone (or system default).
+ */
+function inTz(date: string, timeZone: string = DEFAULT_TZ): TZDate {
+  const iso = toUtcIso(date);
+  return timeZone ? new TZDate(iso, timeZone) : new TZDate(iso);
+}
+
+/**
+ * Format an ISO date string for display (date + time).
+ * @param date - ISO date string (stored as UTC; naive strings treated as UTC).
+ * @param timeZone - IANA timezone (e.g. 'UTC', 'America/New_York'). Omit for browser local.
+ * @param hour12 - true = 12-hour (AM/PM), false = 24-hour. Omit for locale default.
+ */
+export function formatDate(date: string, timeZone?: string, hour12?: boolean): string {
+  const tz = timeZone ?? DEFAULT_TZ;
+  const d = inTz(date, tz);
+  const use12 = hour12 ?? true;
+  return format(d, use12 ? "MMM d, yyyy h:mm a" : "MMM d, yyyy HH:mm");
+}
+
+/**
+ * Format time only (hour:minute) from an ISO date string.
+ * @param date - ISO date string (stored as UTC).
+ * @param timeZone - IANA timezone (optional).
+ * @param hour12 - true = 12-hour (AM/PM), false = 24-hour (optional).
+ */
+export function formatTime(date: string, timeZone?: string, hour12?: boolean): string {
+  const tz = timeZone ?? DEFAULT_TZ;
+  const d = inTz(date, tz);
+  const use12 = hour12 ?? true;
+  return format(d, use12 ? "h:mm a" : "HH:mm");
+}
+
+/**
+ * Format date only (no time) from an ISO date string.
+ * @param date - ISO date string (stored as UTC).
+ * @param timeZone - IANA timezone (optional).
+ */
+export function formatDateOnly(date: string, timeZone?: string): string {
+  const tz = timeZone ?? DEFAULT_TZ;
+  const d = inTz(date, tz);
+  return format(d, "MMM d, yyyy");
+}
+
+/**
+ * Format relative time or fall back to full date.
+ * @param date - ISO date string (stored as UTC).
+ * @param timeZone - IANA timezone (optional).
+ * @param hour12 - true = 12-hour, false = 24-hour (optional).
+ */
+export function formatRelativeTime(date: string, timeZone?: string, hour12?: boolean): string {
   const now = new Date();
-  const then = new Date(date);
+  const iso = toUtcIso(date);
+  const then = new Date(iso || NaN);
   const diffInSeconds = Math.floor((now.getTime() - then.getTime()) / 1000);
 
-  if (diffInSeconds < 60) return 'just now';
+  if (diffInSeconds < 60) return "just now";
   if (diffInSeconds < 3600) return `${Math.floor(diffInSeconds / 60)}m ago`;
   if (diffInSeconds < 86400) return `${Math.floor(diffInSeconds / 3600)}h ago`;
   if (diffInSeconds < 604800) return `${Math.floor(diffInSeconds / 86400)}d ago`;
 
-  return formatDate(date);
+  return formatDate(date, timeZone, hour12);
 }

--- a/frontend/src/pages/AuthPage.tsx
+++ b/frontend/src/pages/AuthPage.tsx
@@ -5,9 +5,20 @@ import { toast } from 'sonner';
 
 export default function AuthPage() {
   const navigate = useNavigate();
-  const { authStatus, connectStrava, connectWithings, saveGarminCredentials, isSavingGarmin, hasAuthToken } = useAuth();
+  const {
+    authStatus,
+    connectStrava,
+    connectWithings,
+    saveGarminCredentials,
+    submitGarminMfa,
+    isSavingGarmin,
+    isSubmittingGarminMfa,
+    hasAuthToken,
+  } = useAuth();
   const [garminEmail, setGarminEmail] = useState('');
   const [garminPassword, setGarminPassword] = useState('');
+  const [garminMfaToken, setGarminMfaToken] = useState<string | null>(null);
+  const [garminMfaCode, setGarminMfaCode] = useState('');
   const [isConnectingStrava, setIsConnectingStrava] = useState(false);
   const [isConnectingWithings, setIsConnectingWithings] = useState(false);
 
@@ -43,13 +54,31 @@ export default function AuthPage() {
   const handleGarminSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await saveGarminCredentials({
+      const result = await saveGarminCredentials({
         email: garminEmail,
         password: garminPassword,
       });
-      toast.success('Garmin credentials saved successfully!');
+      if (result?.mfa_required && result?.mfa_token) {
+        setGarminMfaToken(result.mfa_token);
+        toast.info('Enter the verification code from your authenticator app');
+      } else {
+        toast.success('Garmin credentials saved successfully!');
+      }
     } catch (error: any) {
       toast.error(error.response?.data?.detail || 'Failed to save Garmin credentials');
+    }
+  };
+
+  const handleGarminMfaSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!garminMfaToken || !garminMfaCode.trim()) return;
+    try {
+      await submitGarminMfa(garminMfaToken, garminMfaCode.trim());
+      toast.success('Garmin credentials saved successfully!');
+      setGarminMfaToken(null);
+      setGarminMfaCode('');
+    } catch (error: any) {
+      toast.error(error.response?.data?.detail || 'Invalid verification code');
     }
   };
 
@@ -124,6 +153,45 @@ export default function AuthPage() {
             <div className="border rounded-lg p-6 bg-white shadow-sm">
               <h3 className="text-lg font-medium mb-4">3. Add Garmin Credentials</h3>
               {!authStatus?.garmin_connected ? (
+                garminMfaToken ? (
+                  <form onSubmit={handleGarminMfaSubmit} className="space-y-4">
+                    <p className="text-sm text-gray-600">
+                      Enter the 6-digit code from your authenticator app.
+                    </p>
+                    <div>
+                      <label htmlFor="mfa-code" className="block text-sm font-medium text-gray-700 mb-1">
+                        Verification code
+                      </label>
+                      <input
+                        id="mfa-code"
+                        type="text"
+                        inputMode="numeric"
+                        autoComplete="one-time-code"
+                        placeholder="000000"
+                        maxLength={8}
+                        value={garminMfaCode}
+                        onChange={(e) => setGarminMfaCode(e.target.value.replace(/\D/g, ''))}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary font-mono text-lg tracking-widest"
+                      />
+                    </div>
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        onClick={() => { setGarminMfaToken(null); setGarminMfaCode(''); }}
+                        className="flex-1 py-2 px-4 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50"
+                      >
+                        Back
+                      </button>
+                      <button
+                        type="submit"
+                        disabled={isSubmittingGarminMfa || garminMfaCode.length < 6}
+                        className="flex-1 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        {isSubmittingGarminMfa ? 'Verifying...' : 'Verify'}
+                      </button>
+                    </div>
+                  </form>
+                ) : (
                 <form onSubmit={handleGarminSubmit} className="space-y-4">
                   <div>
                     <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
@@ -159,6 +227,7 @@ export default function AuthPage() {
                     {isSavingGarmin ? 'Saving...' : 'Save Garmin Credentials'}
                   </button>
                 </form>
+                )
               ) : (
                 <div className="flex items-center text-green-600">
                   <svg className="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 20 20">

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -11,6 +11,8 @@ type SyncDirection = 'strava_to_garmin' | 'garmin_to_strava';
 
 export default function DashboardPage() {
   const { authStatus, connectWithings } = useAuth();
+  const displayTimezone = authStatus?.display_timezone ?? 'UTC';
+  const hour12 = authStatus?.display_time_format !== '24h';
   const { syncStats, syncHistory, manualSync, isSyncing, refetch } = useSync();
   const [activeTab, setActiveTab] = useState<SyncDirection>('strava_to_garmin');
   const [stravaActivityId, setStravaActivityId] = useState('');
@@ -235,7 +237,7 @@ export default function DashboardPage() {
                   </span>
                 </div>
                 <div className="text-sm text-gray-500">
-                  {log.activity_type} • {formatRelativeTime(log.created_at)}
+                  {log.activity_type} • {formatRelativeTime(log.created_at, displayTimezone, hour12)}
                 </div>
               </div>
               <span

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -101,8 +101,9 @@ export default function DashboardPage() {
             </div>
           ) : (
             <button
+              type="button"
               onClick={handleWithingsConnect}
-              className="flex items-center gap-2 px-3 py-2 bg-blue-50 text-blue-700 hover:bg-blue-100 rounded-md border border-blue-200 transition-colors"
+              className="flex items-center gap-2 px-3 py-2 bg-blue-50 text-blue-700 hover:bg-blue-100 rounded-md border border-blue-200 transition-colors cursor-pointer"
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 4v16m8-8H4" />
@@ -135,37 +136,39 @@ export default function DashboardPage() {
         </div>
       )}
 
-      {/* Manual Sync Form with Tabs */}
+      {/* Manual Sync Form with Tabs (Garmin→Strava tab only when enabled) */}
       <div className="bg-white rounded-lg shadow">
-        <div className="border-b">
-          <div className="flex">
-            <button
-              onClick={() => setActiveTab('strava_to_garmin')}
-              className={`flex-1 px-4 sm:px-6 py-3 sm:py-4 text-xs sm:text-sm font-medium transition-colors ${
-                activeTab === 'strava_to_garmin'
-                  ? 'border-b-2 border-primary text-primary'
-                  : 'text-gray-500 hover:text-gray-700'
-              }`}
-            >
-              <span className="hidden sm:inline">Strava → Garmin</span>
-              <span className="sm:hidden">S → G</span>
-            </button>
-            <button
-              onClick={() => setActiveTab('garmin_to_strava')}
-              className={`flex-1 px-4 sm:px-6 py-3 sm:py-4 text-xs sm:text-sm font-medium transition-colors ${
-                activeTab === 'garmin_to_strava'
-                  ? 'border-b-2 border-primary text-primary'
-                  : 'text-gray-500 hover:text-gray-700'
-              }`}
-            >
-              <span className="hidden sm:inline">Garmin → Strava</span>
-              <span className="sm:hidden">G → S</span>
-            </button>
+        {authStatus?.garmin_to_strava_sync_disabled !== true ? (
+          <div className="border-b">
+            <div className="flex">
+              <button
+                onClick={() => setActiveTab('strava_to_garmin')}
+                className={`flex-1 px-4 sm:px-6 py-3 sm:py-4 text-xs sm:text-sm font-medium transition-colors ${
+                  activeTab === 'strava_to_garmin'
+                    ? 'border-b-2 border-primary text-primary'
+                    : 'text-gray-500 hover:text-gray-700'
+                }`}
+              >
+                <span className="hidden sm:inline">Strava → Garmin</span>
+                <span className="sm:hidden">S → G</span>
+              </button>
+              <button
+                onClick={() => setActiveTab('garmin_to_strava')}
+                className={`flex-1 px-4 sm:px-6 py-3 sm:py-4 text-xs sm:text-sm font-medium transition-colors ${
+                  activeTab === 'garmin_to_strava'
+                    ? 'border-b-2 border-primary text-primary'
+                    : 'text-gray-500 hover:text-gray-700'
+                }`}
+              >
+                <span className="hidden sm:inline">Garmin → Strava</span>
+                <span className="sm:hidden">G → S</span>
+              </button>
+            </div>
           </div>
-        </div>
+        ) : null}
 
         <div className="p-4 sm:p-6">
-          {activeTab === 'strava_to_garmin' ? (
+          {activeTab === 'strava_to_garmin' || authStatus?.garmin_to_strava_sync_disabled === true ? (
             <div>
               <h2 className="text-base sm:text-lg font-semibold mb-3 sm:mb-4">Sync from Strava to Garmin</h2>
               <form onSubmit={handleManualSync} className="flex flex-col sm:flex-row gap-3 sm:gap-4">
@@ -182,7 +185,7 @@ export default function DashboardPage() {
                 <button
                   type="submit"
                   disabled={isSyncing}
-                  className="bg-primary hover:bg-primary/90 text-white px-4 sm:px-6 py-2 rounded-md font-medium disabled:opacity-50 text-sm sm:text-base whitespace-nowrap"
+                  className="bg-primary hover:bg-primary/90 text-white px-4 sm:px-6 py-2 rounded-md font-medium disabled:opacity-50 text-sm sm:text-base whitespace-nowrap cursor-pointer"
                 >
                   {isSyncing ? 'Syncing...' : 'Sync Activity'}
                 </button>
@@ -203,7 +206,7 @@ export default function DashboardPage() {
                 <button
                   type="submit"
                   disabled={isSyncingGarmin}
-                  className="bg-primary hover:bg-primary/90 text-white px-4 sm:px-6 py-2 rounded-md font-medium disabled:opacity-50 text-sm sm:text-base whitespace-nowrap"
+                  className="bg-primary hover:bg-primary/90 text-white px-4 sm:px-6 py-2 rounded-md font-medium disabled:opacity-50 text-sm sm:text-base whitespace-nowrap cursor-pointer"
                 >
                   {isSyncingGarmin ? 'Syncing...' : 'Sync Activity'}
                 </button>

--- a/frontend/src/pages/FiltersPage.tsx
+++ b/frontend/src/pages/FiltersPage.tsx
@@ -55,8 +55,9 @@ export default function FiltersPage() {
       <div className="flex justify-between items-center">
         <h1 className="text-2xl font-bold">Activity Filters</h1>
         <button
+          type="button"
           onClick={() => setShowForm(!showForm)}
-          className="bg-primary hover:bg-primary/90 text-white px-4 py-2 rounded-md font-medium"
+          className="bg-primary hover:bg-primary/90 text-white px-4 py-2 rounded-md font-medium cursor-pointer"
         >
           {showForm ? 'Cancel' : 'New Filter'}
         </button>
@@ -117,7 +118,7 @@ export default function FiltersPage() {
             <button
               type="submit"
               disabled={isCreating}
-              className="w-full bg-primary hover:bg-primary/90 text-white py-2 rounded-md font-medium disabled:opacity-50"
+              className="w-full bg-primary hover:bg-primary/90 text-white py-2 rounded-md font-medium disabled:opacity-50 cursor-pointer"
             >
               {isCreating ? 'Creating...' : 'Create Filter'}
             </button>
@@ -142,16 +143,18 @@ export default function FiltersPage() {
             </div>
             <div className="flex items-center gap-2">
               <button
+                type="button"
                 onClick={() => toggleActive(filter.id, filter.active)}
-                className={`px-3 py-1 rounded-md text-sm font-medium ${
+                className={`px-3 py-1 rounded-md text-sm font-medium cursor-pointer ${
                   filter.active ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-700'
                 }`}
               >
                 {filter.active ? 'Active' : 'Inactive'}
               </button>
               <button
+                type="button"
                 onClick={() => handleDelete(filter.id)}
-                className="text-red-600 hover:text-red-800 text-sm font-medium"
+                className="text-red-600 hover:text-red-800 text-sm font-medium cursor-pointer"
               >
                 Delete
               </button>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,113 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '../hooks/useAuth';
+import { toast } from 'sonner';
+import { authApi } from '../api/auth';
+
+export default function ProfilePage() {
+  const { authStatus, refetchAuthStatus } = useAuth();
+  const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (authStatus) {
+      setEmail(authStatus.email ?? '');
+      setUsername(authStatus.username ?? '');
+      setFirstName(authStatus.first_name ?? '');
+      setLastName(authStatus.last_name ?? '');
+    }
+  }, [authStatus]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      await authApi.updateProfile({
+        email: email.trim() || undefined,
+        username: username.trim() || null,
+        first_name: firstName.trim() || null,
+        last_name: lastName.trim() || null,
+      });
+      toast.success('Profile updated');
+      refetchAuthStatus();
+    } catch (error: any) {
+      const msg = error.response?.data?.detail ?? 'Failed to update profile';
+      toast.error(typeof msg === 'string' ? msg : 'Failed to update profile');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">Profile</h1>
+      <div className="bg-white rounded-lg shadow p-4 sm:p-6">
+        <form onSubmit={handleSubmit} className="space-y-6 max-w-xl">
+          <div>
+            <label htmlFor="profile-email" className="block text-sm font-medium text-gray-700 mb-1">
+              Email
+            </label>
+            <input
+              id="profile-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="profile-username" className="block text-sm font-medium text-gray-700 mb-1">
+              Username
+            </label>
+            <input
+              id="profile-username"
+              type="text"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              placeholder="Optional"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="profile-first-name" className="block text-sm font-medium text-gray-700 mb-1">
+                First name
+              </label>
+              <input
+                id="profile-first-name"
+                type="text"
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
+                placeholder="Optional"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+            </div>
+            <div>
+              <label htmlFor="profile-last-name" className="block text-sm font-medium text-gray-700 mb-1">
+                Last name
+              </label>
+              <input
+                id="profile-last-name"
+                type="text"
+                value={lastName}
+                onChange={(e) => setLastName(e.target.value)}
+                placeholder="Optional"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+            </div>
+          </div>
+          <button
+            type="submit"
+            disabled={saving}
+            className="bg-primary hover:bg-primary/90 text-white font-medium py-2 px-4 rounded-md disabled:opacity-50 cursor-pointer"
+          >
+            {saving ? 'Saving...' : 'Save profile'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -3,12 +3,25 @@ import { useAuth } from '../hooks/useAuth';
 import { toast } from 'sonner';
 import { authApi } from '../api/auth';
 
+function getDisplayTimezoneOptions(): { value: string; label: string }[] {
+  const utc = { value: 'UTC', label: 'UTC' };
+  if (typeof Intl?.supportedValuesOf !== 'function') return [utc];
+  const rest = Intl.supportedValuesOf('timeZone')
+    .filter((tz) => tz !== 'UTC')
+    .sort()
+    .map((tz) => ({ value: tz, label: tz }));
+  return [utc, ...rest];
+}
+const DISPLAY_TIMEZONE_OPTIONS = getDisplayTimezoneOptions();
+
 export default function ProfilePage() {
   const { authStatus, refetchAuthStatus } = useAuth();
   const [email, setEmail] = useState('');
   const [username, setUsername] = useState('');
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
+  const [displayTimezone, setDisplayTimezone] = useState('UTC');
+  const [displayTimeFormat, setDisplayTimeFormat] = useState<'12h' | '24h'>('12h');
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
@@ -17,6 +30,8 @@ export default function ProfilePage() {
       setUsername(authStatus.username ?? '');
       setFirstName(authStatus.first_name ?? '');
       setLastName(authStatus.last_name ?? '');
+      setDisplayTimezone(authStatus.display_timezone ?? 'UTC');
+      setDisplayTimeFormat((authStatus.display_time_format === '24h' ? '24h' : '12h'));
     }
   }, [authStatus]);
 
@@ -29,6 +44,8 @@ export default function ProfilePage() {
         username: username.trim() || null,
         first_name: firstName.trim() || null,
         last_name: lastName.trim() || null,
+        display_timezone: displayTimezone || 'UTC',
+        display_time_format: displayTimeFormat,
       });
       toast.success('Profile updated');
       refetchAuthStatus();
@@ -98,6 +115,36 @@ export default function ProfilePage() {
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
               />
             </div>
+          </div>
+          <div>
+            <label htmlFor="profile-display-timezone" className="block text-sm font-medium text-gray-700 mb-1">
+              Display timezone
+            </label>
+            <select
+              id="profile-display-timezone"
+              value={displayTimezone}
+              onChange={(e) => setDisplayTimezone(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+            >
+              {DISPLAY_TIMEZONE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+            <p className="text-xs text-gray-500 mt-1">Used for dates in Sync History and elsewhere. Stored times are UTC.</p>
+          </div>
+          <div>
+            <label htmlFor="profile-display-time-format" className="block text-sm font-medium text-gray-700 mb-1">
+              Time format
+            </label>
+            <select
+              id="profile-display-time-format"
+              value={displayTimeFormat}
+              onChange={(e) => setDisplayTimeFormat(e.target.value as '12h' | '24h')}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+            >
+              <option value="12h">12-hour (AM/PM)</option>
+              <option value="24h">24-hour</option>
+            </select>
           </div>
           <button
             type="submit"

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -3,12 +3,24 @@ import { useAuth } from '../hooks/useAuth';
 import { useSync } from '../hooks/useSync';
 import { toast } from 'sonner';
 import { authApi } from '../api/auth';
+import { SYNC_SCHEDULE_OPTIONS } from '../types/auth';
+import type { FitDeviceSettings } from '../types/auth';
+
+const DEFAULT_DEVICE: FitDeviceSettings = {
+  device_name: '',
+  serial_number: '',
+  product_id: '',
+  manufacturer_id: '',
+  software_version: '',
+};
 
 export default function SettingsPage() {
   const { refetchAuthStatus } = useAuth();
   const { refetch } = useSync();
   const [settingsGarminToStravaDisabled, setSettingsGarminToStravaDisabled] = useState(false);
   const [settingsAllowExportWithoutGps, setSettingsAllowExportWithoutGps] = useState(false);
+  const [settingsSyncScheduleMinutes, setSettingsSyncScheduleMinutes] = useState(5);
+  const [fitDevice, setFitDevice] = useState<FitDeviceSettings>(DEFAULT_DEVICE);
   const [settingsLoading, setSettingsLoading] = useState(false);
   const [settingsSaving, setSettingsSaving] = useState(false);
 
@@ -19,6 +31,8 @@ export default function SettingsPage() {
       .then((s) => {
         setSettingsGarminToStravaDisabled(s.garmin_to_strava_sync_disabled);
         setSettingsAllowExportWithoutGps(s.allow_export_without_gps);
+        setSettingsSyncScheduleMinutes(s.sync_schedule_minutes ?? 5);
+        setFitDevice({ ...DEFAULT_DEVICE, ...s.fit_device_settings });
       })
       .catch(() => toast.error('Failed to load settings'))
       .finally(() => setSettingsLoading(false));
@@ -31,6 +45,8 @@ export default function SettingsPage() {
       await authApi.updateSettings({
         garmin_to_strava_sync_disabled: settingsGarminToStravaDisabled,
         allow_export_without_gps: settingsAllowExportWithoutGps,
+        sync_schedule_minutes: settingsSyncScheduleMinutes,
+        fit_device_settings: fitDevice,
       });
       toast.success('Settings saved');
       refetchAuthStatus();
@@ -89,6 +105,56 @@ export default function SettingsPage() {
                 <p className="text-sm text-gray-500 mt-0.5">
                   When enabled, indoor or manual activities (no GPS) can be synced in both directions: Strava → Garmin and Garmin → Strava. When disabled, only activities with GPS are synced.
                 </p>
+              </div>
+            </div>
+            <div>
+              <label htmlFor="sync-schedule" className="font-medium text-gray-900 block mb-1">
+                Sync schedule
+              </label>
+              <select
+                id="sync-schedule"
+                value={settingsSyncScheduleMinutes}
+                onChange={(e) => setSettingsSyncScheduleMinutes(Number(e.target.value))}
+                className="mt-1 block w-full max-w-xs rounded-md border border-gray-300 bg-white py-2 pl-3 pr-8 text-base focus:border-primary focus:ring-primary sm:text-sm"
+              >
+                {SYNC_SCHEDULE_OPTIONS.map(({ value, label }) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+              <p className="text-sm text-gray-500 mt-0.5">
+                How often to check for new activities to sync. Default is 5 minutes.
+              </p>
+            </div>
+            <div className="border-t border-gray-200 pt-6">
+              <h2 className="font-medium text-gray-900 mb-2">FIT device settings</h2>
+              <p className="text-sm text-gray-500 mb-4">
+                Device info written into exported FIT files (Strava → Garmin): device name, serial number, manufacturer ID, software version (e.g. 20.29), product ID (0–65535). Optional.
+              </p>
+              <div className="space-y-4 max-w-xl">
+                {[
+                  { key: 'device_name' as const, label: 'Device Name' },
+                  { key: 'serial_number' as const, label: 'Serial Number' },
+                  { key: 'product_id' as const, label: 'Product ID (FIT product, 0–65535)' },
+                  { key: 'manufacturer_id' as const, label: 'Manufacturer ID' },
+                  { key: 'software_version' as const, label: 'Software Version (e.g. 20.29)' },
+                ].map(({ key, label }) => (
+                  <div key={key}>
+                    <label htmlFor={key} className="block text-sm font-medium text-gray-700 mb-0.5">
+                      {label}
+                    </label>
+                    <input
+                      id={key}
+                      type="text"
+                      value={fitDevice[key] ?? ''}
+                      onChange={(e) =>
+                        setFitDevice((prev) => ({ ...prev, [key]: e.target.value || undefined }))
+                      }
+                      className="block w-full rounded-md border border-gray-300 bg-white py-1.5 px-2 text-sm focus:border-primary focus:ring-primary"
+                    />
+                  </div>
+                ))}
               </div>
             </div>
             <button

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '../hooks/useAuth';
+import { useSync } from '../hooks/useSync';
+import { toast } from 'sonner';
+import { authApi } from '../api/auth';
+
+export default function SettingsPage() {
+  const { refetchAuthStatus } = useAuth();
+  const { refetch } = useSync();
+  const [settingsGarminToStravaDisabled, setSettingsGarminToStravaDisabled] = useState(false);
+  const [settingsAllowExportWithoutGps, setSettingsAllowExportWithoutGps] = useState(false);
+  const [settingsLoading, setSettingsLoading] = useState(false);
+  const [settingsSaving, setSettingsSaving] = useState(false);
+
+  useEffect(() => {
+    setSettingsLoading(true);
+    authApi
+      .getSettings()
+      .then((s) => {
+        setSettingsGarminToStravaDisabled(s.garmin_to_strava_sync_disabled);
+        setSettingsAllowExportWithoutGps(s.allow_export_without_gps);
+      })
+      .catch(() => toast.error('Failed to load settings'))
+      .finally(() => setSettingsLoading(false));
+  }, []);
+
+  const handleSaveSettings = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSettingsSaving(true);
+    try {
+      await authApi.updateSettings({
+        garmin_to_strava_sync_disabled: settingsGarminToStravaDisabled,
+        allow_export_without_gps: settingsAllowExportWithoutGps,
+      });
+      toast.success('Settings saved');
+      refetchAuthStatus();
+      refetch();
+    } catch (error: any) {
+      const res = error.response;
+      const detail = res?.data?.detail;
+      let message = 'Failed to save settings';
+      if (typeof detail === 'string') message = detail;
+      else if (Array.isArray(detail) && detail[0]?.msg) message = detail[0].msg;
+      else if (res?.status) message = `Error ${res.status}: ${message}`;
+      console.error('Save settings failed:', res?.status, res?.data, error.message);
+      toast.error(message);
+    } finally {
+      setSettingsSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">Settings</h1>
+      <div className="bg-white rounded-lg shadow p-4 sm:p-6">
+        {settingsLoading ? (
+          <div className="text-gray-500">Loading settings...</div>
+        ) : (
+          <form onSubmit={handleSaveSettings} className="space-y-6 max-w-xl">
+            <div className="flex items-start gap-4">
+              <input
+                id="garmin-to-strava-disabled"
+                type="checkbox"
+                checked={settingsGarminToStravaDisabled}
+                onChange={(e) => setSettingsGarminToStravaDisabled(e.target.checked)}
+                className="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
+              />
+              <div>
+                <label htmlFor="garmin-to-strava-disabled" className="font-medium text-gray-900 cursor-pointer">
+                  Disable Garmin → Strava sync
+                </label>
+                <p className="text-sm text-gray-500 mt-0.5">
+                  When checked, Garmin → Strava sync is off (only Strava → Garmin runs). When unchecked, activities are synced both ways (Strava ↔ Garmin).
+                </p>
+              </div>
+            </div>
+            <div className="flex items-start gap-4">
+              <input
+                id="export-without-gps"
+                type="checkbox"
+                checked={settingsAllowExportWithoutGps}
+                onChange={(e) => setSettingsAllowExportWithoutGps(e.target.checked)}
+                className="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
+              />
+              <div>
+                <label htmlFor="export-without-gps" className="font-medium text-gray-900 cursor-pointer">
+                  Enable export without GPS
+                </label>
+                <p className="text-sm text-gray-500 mt-0.5">
+                  When enabled, indoor or manual activities (no GPS) can be synced in both directions: Strava → Garmin and Garmin → Strava. When disabled, only activities with GPS are synced.
+                </p>
+              </div>
+            </div>
+            <button
+              type="submit"
+              disabled={settingsSaving}
+              className="bg-primary hover:bg-primary/90 text-white font-medium py-2 px-4 rounded-md disabled:opacity-50 cursor-pointer"
+            >
+              {settingsSaving ? 'Saving...' : 'Save settings'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -14,6 +14,137 @@ const DEFAULT_DEVICE: FitDeviceSettings = {
   software_version: '',
 };
 
+function GarminReAuthSection() {
+  const { saveGarminCredentials, submitGarminMfa, isSavingGarmin, isSubmittingGarminMfa, refetchAuthStatus } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [mfaToken, setMfaToken] = useState<string | null>(null);
+  const [mfaCode, setMfaCode] = useState('');
+
+  const handleCredentialsSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const result = await saveGarminCredentials({ email, password });
+      if (result?.mfa_required && result?.mfa_token) {
+        setMfaToken(result.mfa_token);
+        toast.info('Enter the 6-digit code from your authenticator app');
+      } else {
+        toast.success('Garmin credentials saved');
+        setEmail('');
+        setPassword('');
+        refetchAuthStatus();
+      }
+    } catch (err: any) {
+      toast.error(err.response?.data?.detail || 'Failed to save Garmin credentials');
+    }
+  };
+
+  const handleMfaSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!mfaToken || !mfaCode.trim()) return;
+    try {
+      await submitGarminMfa(mfaToken, mfaCode.trim());
+      toast.success('Garmin re-authenticated successfully');
+      setMfaToken(null);
+      setMfaCode('');
+      setEmail('');
+      setPassword('');
+      refetchAuthStatus();
+    } catch (err: any) {
+      toast.error(err.response?.data?.detail || 'Invalid verification code');
+    }
+  };
+
+  return (
+    <div className="border-t border-gray-200 pt-6">
+      <h2 className="font-medium text-gray-900 mb-1">Garmin account</h2>
+      <p className="text-sm text-gray-500 mb-4">
+        Re-enter your Garmin credentials if the connection has expired or MFA was requested.
+        This will refresh the stored session without affecting any other settings.
+      </p>
+
+      {mfaToken ? (
+        <form onSubmit={handleMfaSubmit} className="space-y-4 max-w-sm">
+          <p className="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
+            Garmin requires a verification code. Enter the 6-digit code from your authenticator app.
+          </p>
+          <div>
+            <label htmlFor="settings-mfa-code" className="block text-sm font-medium text-gray-700 mb-1">
+              Verification code
+            </label>
+            <input
+              id="settings-mfa-code"
+              type="text"
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              placeholder="000000"
+              maxLength={8}
+              value={mfaCode}
+              onChange={(e) => setMfaCode(e.target.value.replace(/\D/g, ''))}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary font-mono text-lg tracking-widest"
+              autoFocus
+            />
+          </div>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={() => { setMfaToken(null); setMfaCode(''); }}
+              className="flex-1 py-2 px-4 border border-gray-300 rounded-md text-sm text-gray-700 hover:bg-gray-50 cursor-pointer"
+            >
+              Back
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmittingGarminMfa || mfaCode.length < 6}
+              className="flex-1 py-2 px-4 bg-primary text-white rounded-md text-sm font-medium hover:bg-primary/90 disabled:opacity-50 cursor-pointer"
+            >
+              {isSubmittingGarminMfa ? 'Verifying…' : 'Verify'}
+            </button>
+          </div>
+        </form>
+      ) : (
+        <form onSubmit={handleCredentialsSubmit} className="space-y-4 max-w-sm">
+          <div>
+            <label htmlFor="settings-garmin-email" className="block text-sm font-medium text-gray-700 mb-1">
+              Garmin email
+            </label>
+            <input
+              id="settings-garmin-email"
+              type="email"
+              required
+              autoComplete="username"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary text-sm"
+            />
+          </div>
+          <div>
+            <label htmlFor="settings-garmin-password" className="block text-sm font-medium text-gray-700 mb-1">
+              Garmin password
+            </label>
+            <input
+              id="settings-garmin-password"
+              type="password"
+              required
+              autoComplete="current-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary text-sm"
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={isSavingGarmin}
+            className="w-full py-2 px-4 bg-primary text-white rounded-md text-sm font-medium hover:bg-primary/90 disabled:opacity-50 cursor-pointer"
+          >
+            {isSavingGarmin ? 'Connecting…' : 'Re-authenticate Garmin'}
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}
+
 export default function SettingsPage() {
   const { refetchAuthStatus } = useAuth();
   const { refetch } = useSync();
@@ -166,6 +297,11 @@ export default function SettingsPage() {
             </button>
           </form>
         )}
+      </div>
+
+      {/* Garmin re-auth — always visible so users can fix a broken session */}
+      <div className="bg-white rounded-lg shadow p-4 sm:p-6">
+        <GarminReAuthSection />
       </div>
     </div>
   );

--- a/frontend/src/pages/SyncHistoryPage.test.tsx
+++ b/frontend/src/pages/SyncHistoryPage.test.tsx
@@ -9,10 +9,13 @@ vi.mock('../hooks/useSync', () => ({
   useSync: vi.fn(),
 }));
 
-// Mock syncApi
+// Mock api (syncApi + authApi for useAuth display_timezone)
 vi.mock('../api', () => ({
   syncApi: {
     getSyncLogDetails: vi.fn(),
+  },
+  authApi: {
+    getAuthStatus: vi.fn().mockResolvedValue({ display_timezone: 'UTC' }),
   },
 }));
 

--- a/frontend/src/pages/SyncHistoryPage.tsx
+++ b/frontend/src/pages/SyncHistoryPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useSync } from '../hooks/useSync';
+import { useAuth } from '../hooks/useAuth';
 import { syncApi } from '../api';
 import type { SyncLog, SyncLogDetails, BulkDeleteSyncLogsParams } from '../types';
 import { toast } from 'sonner';
@@ -7,12 +8,16 @@ import { formatDate } from '../lib/utils';
 import { SYNC_STATUS_COLORS, SYNC_STATUS_LABELS } from '../lib/constants';
 
 export default function SyncHistoryPage() {
+  const { authStatus } = useAuth();
+  const displayTimezone = authStatus?.display_timezone ?? 'UTC';
+  const hour12 = authStatus?.display_time_format !== '24h';
   const { syncHistory, retrySync, deleteSyncLog, bulkDeleteSyncLogs, isRetrying, isDeleting } = useSync();
   const [showBulkDelete, setShowBulkDelete] = useState(false);
   const [bulkDeleteStatus, setBulkDeleteStatus] = useState<string>('');
   const [directionFilter, setDirectionFilter] = useState<string>('all');
   const [selectedLogDetails, setSelectedLogDetails] = useState<SyncLogDetails | null>(null);
   const [loadingDetails, setLoadingDetails] = useState(false);
+  const [downloadingFitId, setDownloadingFitId] = useState<number | null>(null);
 
   // Filter sync history by direction
   const filteredHistory = syncHistory.filter((log: SyncLog) => {
@@ -71,6 +76,20 @@ export default function SyncHistoryPage() {
       toast.error(error.response?.data?.detail || 'Failed to load details');
     } finally {
       setLoadingDetails(false);
+    }
+  };
+
+  const handleDownloadFit = async (log: SyncLog) => {
+    if (log.status !== 'success') return;
+    setDownloadingFitId(log.id);
+    try {
+      await syncApi.downloadFit(log.id, log.source_activity_id);
+      toast.success('FIT file downloaded');
+    } catch (error: any) {
+      const detail = error.response?.data instanceof Blob ? 'Download failed' : (error.response?.data?.detail || 'Failed to download FIT');
+      toast.error(detail);
+    } finally {
+      setDownloadingFitId(null);
     }
   };
 
@@ -178,7 +197,7 @@ export default function SyncHistoryPage() {
                     {SYNC_STATUS_LABELS[log.status]}
                   </span>
                 </div>
-                <div className="text-sm text-gray-600">{formatDate(log.created_at)}</div>
+                <div className="text-sm text-gray-600">{formatDate(log.created_at, displayTimezone, hour12)}</div>
                 <div className="flex gap-2 flex-col">
                   <button
                     type="button"
@@ -188,6 +207,16 @@ export default function SyncHistoryPage() {
                   >
                     Details
                   </button>
+                  {log.status === 'success' && (
+                    <button
+                      type="button"
+                      onClick={() => handleDownloadFit(log)}
+                      disabled={downloadingFitId !== null}
+                      className="text-sm text-green-600 hover:text-green-800 font-medium disabled:opacity-50 cursor-pointer"
+                    >
+                      {downloadingFitId === log.id ? 'Downloading…' : 'Download FIT'}
+                    </button>
+                  )}
                   {log.status === 'failed' && (
                     <button
                       type="button"
@@ -257,6 +286,10 @@ export default function SyncHistoryPage() {
                     <div><strong>Source Activity ID:</strong> {selectedLogDetails.source_activity_id}</div>
                     <div><strong>Target Activity ID:</strong> {selectedLogDetails.target_activity_id || 'N/A'}</div>
                     <div><strong>Status:</strong> {selectedLogDetails.status}</div>
+                    <div><strong>Created:</strong> {formatDate(selectedLogDetails.created_at, displayTimezone, hour12)}</div>
+                    {selectedLogDetails.completed_at && (
+                      <div><strong>Completed:</strong> {formatDate(selectedLogDetails.completed_at, displayTimezone, hour12)}</div>
+                    )}
                   </div>
                 </div>
 
@@ -334,7 +367,17 @@ export default function SyncHistoryPage() {
                 )}
               </div>
             </div>
-            <div className="px-6 py-4 border-t flex justify-end">
+            <div className="px-6 py-4 border-t flex justify-end gap-2">
+              {selectedLogDetails.status === 'success' && (
+                <button
+                  type="button"
+                  onClick={() => handleDownloadFit(selectedLogDetails as SyncLog)}
+                  disabled={downloadingFitId !== null}
+                  className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-md font-medium disabled:opacity-50 cursor-pointer"
+                >
+                  {downloadingFitId === selectedLogDetails.id ? 'Downloading…' : 'Download FIT'}
+                </button>
+              )}
               <button
                 type="button"
                 onClick={() => setSelectedLogDetails(null)}

--- a/frontend/src/pages/SyncHistoryPage.tsx
+++ b/frontend/src/pages/SyncHistoryPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useSync } from '../hooks/useSync';
 import { syncApi } from '../api';
+import type { SyncLog, SyncLogDetails, BulkDeleteSyncLogsParams } from '../types';
 import { toast } from 'sonner';
 import { formatDate } from '../lib/utils';
 import { SYNC_STATUS_COLORS, SYNC_STATUS_LABELS } from '../lib/constants';
@@ -10,11 +11,11 @@ export default function SyncHistoryPage() {
   const [showBulkDelete, setShowBulkDelete] = useState(false);
   const [bulkDeleteStatus, setBulkDeleteStatus] = useState<string>('');
   const [directionFilter, setDirectionFilter] = useState<string>('all');
-  const [selectedLogDetails, setSelectedLogDetails] = useState<any>(null);
+  const [selectedLogDetails, setSelectedLogDetails] = useState<SyncLogDetails | null>(null);
   const [loadingDetails, setLoadingDetails] = useState(false);
 
   // Filter sync history by direction
-  const filteredHistory = syncHistory.filter(log => {
+  const filteredHistory = syncHistory.filter((log: SyncLog) => {
     if (directionFilter === 'all') return true;
     return log.sync_direction === directionFilter;
   });
@@ -40,9 +41,9 @@ export default function SyncHistoryPage() {
   };
 
   const handleBulkDelete = async () => {
-    const filters: any = {};
+    const filters: BulkDeleteSyncLogsParams = {};
     if (bulkDeleteStatus) {
-      filters.status = bulkDeleteStatus;
+      filters.status = bulkDeleteStatus as BulkDeleteSyncLogsParams['status'];
     }
 
     const message = bulkDeleteStatus
@@ -92,8 +93,9 @@ export default function SyncHistoryPage() {
             </select>
           </div>
           <button
+            type="button"
             onClick={() => setShowBulkDelete(!showBulkDelete)}
-            className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-md font-medium"
+            className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-md font-medium cursor-pointer"
           >
             {showBulkDelete ? 'Cancel' : 'Bulk Delete'}
           </button>
@@ -121,9 +123,10 @@ export default function SyncHistoryPage() {
               </select>
             </div>
             <button
+              type="button"
               onClick={handleBulkDelete}
               disabled={isDeleting}
-              className="w-full bg-red-600 hover:bg-red-700 text-white py-2 rounded-md font-medium disabled:opacity-50"
+              className="w-full bg-red-600 hover:bg-red-700 text-white py-2 rounded-md font-medium disabled:opacity-50 cursor-pointer"
             >
               Delete Logs
             </button>
@@ -178,25 +181,28 @@ export default function SyncHistoryPage() {
                 <div className="text-sm text-gray-600">{formatDate(log.created_at)}</div>
                 <div className="flex gap-2 flex-col">
                   <button
+                    type="button"
                     onClick={() => handleViewDetails(log.id)}
                     disabled={loadingDetails}
-                    className="text-sm text-blue-600 hover:text-blue-800 font-medium disabled:opacity-50"
+                    className="text-sm text-blue-600 hover:text-blue-800 font-medium disabled:opacity-50 cursor-pointer"
                   >
                     Details
                   </button>
                   {log.status === 'failed' && (
                     <button
+                      type="button"
                       onClick={() => handleRetry(log.id)}
                       disabled={isRetrying}
-                      className="text-sm text-primary hover:text-primary/80 font-medium disabled:opacity-50"
+                      className="text-sm text-primary hover:text-primary/80 font-medium disabled:opacity-50 cursor-pointer"
                     >
                       Retry
                     </button>
                   )}
                   <button
+                    type="button"
                     onClick={() => handleDelete(log.id)}
                     disabled={isDeleting}
-                    className="text-sm text-red-600 hover:text-red-800 font-medium disabled:opacity-50"
+                    className="text-sm text-red-600 hover:text-red-800 font-medium disabled:opacity-50 cursor-pointer"
                   >
                     Delete
                   </button>
@@ -224,8 +230,9 @@ export default function SyncHistoryPage() {
             <div className="px-6 py-4 border-b flex justify-between items-center">
               <h2 className="text-xl font-bold">Sync Details</h2>
               <button
+                type="button"
                 onClick={() => setSelectedLogDetails(null)}
-                className="text-gray-500 hover:text-gray-700"
+                className="text-gray-500 hover:text-gray-700 cursor-pointer"
               >
                 <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -254,7 +261,7 @@ export default function SyncHistoryPage() {
                 </div>
 
                 {/* Strava Data */}
-                {selectedLogDetails.strava_data && (
+                {selectedLogDetails.strava_data != null ? (
                   <div>
                     <h3 className="text-lg font-semibold mb-2">Strava Activity Data</h3>
                     <div className="bg-gray-50 p-4 rounded">
@@ -263,7 +270,7 @@ export default function SyncHistoryPage() {
                       </pre>
                     </div>
                   </div>
-                )}
+                ) : null}
 
                 {/* FIT Data Summary */}
                 {selectedLogDetails.gpx_data && (
@@ -329,8 +336,9 @@ export default function SyncHistoryPage() {
             </div>
             <div className="px-6 py-4 border-t flex justify-end">
               <button
+                type="button"
                 onClick={() => setSelectedLogDetails(null)}
-                className="bg-gray-200 hover:bg-gray-300 text-gray-800 px-4 py-2 rounded-md font-medium"
+                className="bg-gray-200 hover:bg-gray-300 text-gray-800 px-4 py-2 rounded-md font-medium cursor-pointer"
               >
                 Close
               </button>

--- a/frontend/src/pages/SyncHistoryPage.tsx
+++ b/frontend/src/pages/SyncHistoryPage.tsx
@@ -180,8 +180,8 @@ export default function SyncHistoryPage() {
                 </div>
                 <div>
                   <span className="text-xs px-2 py-1 rounded bg-gray-100 text-gray-700 font-medium">
-                    {log.sync_direction === 'strava_to_garmin' 
-                      ? 'S → G' 
+                    {log.sync_direction === 'strava_to_garmin'
+                      ? 'S → G'
                       : log.sync_direction === 'garmin_to_strava'
                         ? 'G → S'
                         : 'W → G'}
@@ -254,7 +254,7 @@ export default function SyncHistoryPage() {
 
       {/* Details Modal */}
       {selectedLogDetails && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
           <div className="bg-white rounded-lg shadow-xl max-w-4xl w-full max-h-[90vh] overflow-hidden flex flex-col">
             <div className="px-6 py-4 border-b flex justify-between items-center">
               <h2 className="text-xl font-bold">Sync Details</h2>
@@ -277,14 +277,19 @@ export default function SyncHistoryPage() {
                     <div><strong>Activity Name:</strong> {selectedLogDetails.activity_name || 'N/A'}</div>
                     <div><strong>Activity Type:</strong> {selectedLogDetails.activity_type || 'N/A'}</div>
                     <div><strong>Sync Direction:</strong> {
-                      selectedLogDetails.sync_direction === 'strava_to_garmin' 
-                        ? 'Strava → Garmin' 
+                      selectedLogDetails.sync_direction === 'strava_to_garmin'
+                        ? 'Strava → Garmin'
                         : selectedLogDetails.sync_direction === 'garmin_to_strava'
                           ? 'Garmin → Strava'
                           : 'Withings → Garmin'
                     }</div>
                     <div><strong>Source Activity ID:</strong> {selectedLogDetails.source_activity_id}</div>
-                    <div><strong>Target Activity ID:</strong> {selectedLogDetails.target_activity_id || 'N/A'}</div>
+                    <div><strong>Target Activity ID:</strong> {
+                      selectedLogDetails.target_activity_id || selectedLogDetails.garmin_activity_id || 'N/A'
+                    }</div>
+                    {selectedLogDetails.uploaded_file_extension && (
+                      <div><strong>File Type Sent:</strong> {selectedLogDetails.uploaded_file_extension.toUpperCase()}</div>
+                    )}
                     <div><strong>Status:</strong> {selectedLogDetails.status}</div>
                     <div><strong>Created:</strong> {formatDate(selectedLogDetails.created_at, displayTimezone, hour12)}</div>
                     {selectedLogDetails.completed_at && (
@@ -305,49 +310,96 @@ export default function SyncHistoryPage() {
                   </div>
                 ) : null}
 
-                {/* FIT Data Summary */}
-                {selectedLogDetails.gpx_data && (
+                {/* File Summary and Garmin Response */}
+                {selectedLogDetails.garmin_data && (
                   <div>
-                    <h3 className="text-lg font-semibold mb-2">FIT File Sent to Garmin</h3>
+                    <h3 className="text-lg font-semibold mb-2">File Information & Garmin Response</h3>
                     <div className="bg-gray-50 p-4 rounded">
                       {(() => {
                         try {
-                          // Try to parse as Python dict string (e.g., "{'format': 'FIT', ...}")
-                          const cleaned = selectedLogDetails.gpx_data
-                            .replace(/'/g, '"')  // Replace single quotes with double quotes
-                            .replace(/None/g, 'null')  // Replace None with null
-                            .replace(/True/g, 'true')  // Replace True with true
-                            .replace(/False/g, 'false');  // Replace False with false
-                          const fitData = JSON.parse(cleaned);
+                          // Try to parse as JSON (could be Python dict string or JSON)
+                          let cleaned = selectedLogDetails.garmin_data;
+                          if (!cleaned.startsWith('{')) {
+                            // Try to parse as Python dict string (e.g., "{'format': 'FIT', ...}")
+                            cleaned = cleaned
+                              .replace(/'/g, '"')  // Replace single quotes with double quotes
+                              .replace(/None/g, 'null')  // Replace None with null
+                              .replace(/True/g, 'true')  // Replace True with true
+                              .replace(/False/g, 'false');  // Replace False with false
+                          }
+                          const data = JSON.parse(cleaned);
 
                           return (
-                            <div className="space-y-2">
-                              <div><strong>Format:</strong> {fitData.format}</div>
-                              <div><strong>File Size:</strong> {(fitData.size_bytes / 1024).toFixed(2)} KB</div>
-                              <div><strong>GPS Points:</strong> {fitData.num_gps_points?.toLocaleString()}</div>
-                              <div><strong>Activity Type:</strong> {fitData.activity_type}</div>
-                              <div><strong>Sport:</strong> {fitData.sport}</div>
-                              {fitData.duration_seconds && (
-                                <div><strong>Duration:</strong> {Math.floor(fitData.duration_seconds / 60)} minutes {Math.floor(fitData.duration_seconds % 60)} seconds</div>
+                            <div className="space-y-4">
+                              {/* File Summary */}
+                              {data.format && (
+                                <div>
+                                  <h4 className="font-semibold mb-2">File Sent to Garmin</h4>
+                                  <div className="space-y-2 pl-4 border-l-2 border-gray-300">
+                                    <div><strong>Format:</strong> {data.format}</div>
+                                    {data.size_bytes && (
+                                      <div><strong>File Size:</strong> {(data.size_bytes / 1024).toFixed(2)} KB</div>
+                                    )}
+                                    {data.num_gps_points !== undefined && (
+                                      <div><strong>GPS Points:</strong> {data.num_gps_points?.toLocaleString()}</div>
+                                    )}
+                                    {data.activity_type && (
+                                      <div><strong>Activity Type:</strong> {data.activity_type}</div>
+                                    )}
+                                    {data.sport && (
+                                      <div><strong>Sport:</strong> {data.sport}</div>
+                                    )}
+                                    {data.duration_seconds && (
+                                      <div><strong>Duration:</strong> {Math.floor(data.duration_seconds / 60)} minutes {Math.floor(data.duration_seconds % 60)} seconds</div>
+                                    )}
+                                    {data.distance_meters && (
+                                      <div><strong>Distance:</strong> {(data.distance_meters / 1000).toFixed(2)} km</div>
+                                    )}
+                                    {data.source && (
+                                      <div><strong>Source:</strong> {data.source}</div>
+                                    )}
+                                    {data.fallback && (
+                                      <div className="text-yellow-600"><strong>Note:</strong> Fallback to FIT generation</div>
+                                    )}
+                                  </div>
+                                </div>
                               )}
-                              {fitData.distance_meters && (
-                                <div><strong>Distance:</strong> {(fitData.distance_meters / 1000).toFixed(2)} km</div>
+
+                              {/* Garmin Upload Response */}
+                              {data.garmin_upload_response && (
+                                <div>
+                                  <h4 className="font-semibold mb-2">Garmin Upload Response</h4>
+                                  <div className="bg-blue-50 p-3 rounded border-l-2 border-blue-400">
+                                    <pre className="text-xs overflow-x-auto whitespace-pre-wrap">
+                                      {JSON.stringify(data.garmin_upload_response, null, 2)}
+                                    </pre>
+                                  </div>
+                                </div>
+                              )}
+
+                              {/* Legacy format (if no format field) */}
+                              {!data.format && !data.garmin_upload_response && (
+                                <div className="space-y-2">
+                                  {Object.entries(data).map(([key, value]) => (
+                                    <div key={key}><strong>{key}:</strong> {String(value)}</div>
+                                  ))}
+                                </div>
                               )}
                             </div>
                           );
                         } catch (e) {
                           // If parsing fails, show as plain text (legacy data or hex)
-                          const isHex = /^[0-9a-f]+$/i.test(selectedLogDetails.gpx_data);
-                          if (isHex && selectedLogDetails.gpx_data.length > 1000) {
+                          const isHex = /^[0-9a-f]+$/i.test(selectedLogDetails.garmin_data);
+                          if (isHex && selectedLogDetails.garmin_data.length > 1000) {
                             return (
                               <div className="text-sm text-gray-600">
-                                FIT file (binary data): {(selectedLogDetails.gpx_data.length / 2 / 1024).toFixed(2)} KB
+                                File (binary data): {(selectedLogDetails.garmin_data.length / 2 / 1024).toFixed(2)} KB
                               </div>
                             );
                           }
                           return (
                             <pre className="text-xs overflow-x-auto whitespace-pre-wrap max-h-96">
-                              {selectedLogDetails.gpx_data}
+                              {selectedLogDetails.garmin_data}
                             </pre>
                           );
                         }
@@ -368,7 +420,7 @@ export default function SyncHistoryPage() {
               </div>
             </div>
             <div className="px-6 py-4 border-t flex justify-end gap-2">
-              {selectedLogDetails.status === 'success' && (
+              {selectedLogDetails.status === 'success' && selectedLogDetails.file_available && (
                 <button
                   type="button"
                   onClick={() => handleDownloadFit(selectedLogDetails as SyncLog)}

--- a/frontend/src/pages/WorkoutSchedulePage.tsx
+++ b/frontend/src/pages/WorkoutSchedulePage.tsx
@@ -1,0 +1,491 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { workoutsApi } from '../api';
+import type { GarminWorkout, WorkoutSchedule, SyncSchedulesResult } from '../types';
+import { useAuth } from '../hooks/useAuth';
+
+const SYNC_DAYS = 30;
+
+const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+function resolveWorkoutName(w: GarminWorkout): string {
+  return w.workoutName ?? w.name ?? `Workout ${w.workoutId}`;
+}
+
+function DayPicker({
+  selected,
+  onChange,
+}: {
+  selected: number[];
+  onChange: (days: number[]) => void;
+}) {
+  const toggle = (day: number) => {
+    onChange(
+      selected.includes(day) ? selected.filter((d) => d !== day) : [...selected, day].sort(),
+    );
+  };
+  return (
+    <div className="flex gap-1 flex-wrap">
+      {DAY_LABELS.map((label, idx) => (
+        <button
+          key={idx}
+          type="button"
+          onClick={() => toggle(idx)}
+          className={`w-10 h-10 rounded-full text-xs font-semibold border transition-colors cursor-pointer ${
+            selected.includes(idx)
+              ? 'bg-primary text-white border-primary'
+              : 'bg-white text-gray-600 border-gray-300 hover:border-primary hover:text-primary'
+          }`}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ScheduleRow({
+  schedule,
+  onDelete,
+  onToggle,
+}: {
+  schedule: WorkoutSchedule;
+  onDelete: (id: number) => void;
+  onToggle: (id: number, active: boolean) => void;
+}) {
+  return (
+    <div
+      className={`flex items-center justify-between p-4 rounded-lg border ${
+        schedule.is_active ? 'bg-white border-gray-200' : 'bg-gray-50 border-gray-200 opacity-60'
+      }`}
+    >
+      <div className="flex-1 min-w-0">
+        <p className="font-medium text-gray-900 truncate">{schedule.workout_name}</p>
+        <div className="flex gap-1 mt-1 flex-wrap">
+          {DAY_LABELS.map((label, idx) => (
+            <span
+              key={idx}
+              className={`px-2 py-0.5 rounded text-xs font-medium ${
+                schedule.days_of_week.includes(idx)
+                  ? 'bg-primary/10 text-primary'
+                  : 'bg-gray-100 text-gray-400'
+              }`}
+            >
+              {label}
+            </span>
+          ))}
+        </div>
+      </div>
+      <div className="flex items-center gap-2 ml-4 shrink-0">
+        <button
+          type="button"
+          onClick={() => onToggle(schedule.id, !schedule.is_active)}
+          className={`text-xs px-3 py-1 rounded border cursor-pointer transition-colors ${
+            schedule.is_active
+              ? 'border-gray-300 text-gray-600 hover:bg-gray-50'
+              : 'border-green-400 text-green-700 hover:bg-green-50'
+          }`}
+        >
+          {schedule.is_active ? 'Pause' : 'Resume'}
+        </button>
+        <button
+          type="button"
+          onClick={() => onDelete(schedule.id)}
+          className="text-xs px-3 py-1 rounded border border-red-300 text-red-600 hover:bg-red-50 cursor-pointer transition-colors"
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function WorkoutSchedulePage() {
+  const { authStatus } = useAuth();
+  const navigate = useNavigate();
+  const garminConnected = authStatus?.garmin_connected ?? false;
+
+  // ── workout library ──────────────────────────────────────────────────
+  const [library, setLibrary] = useState<GarminWorkout[]>([]);
+  const [loadingLibrary, setLoadingLibrary] = useState(false);
+  const [libraryError, setLibraryError] = useState<string | null>(null);
+
+  // ── schedules ────────────────────────────────────────────────────────
+  const [schedules, setSchedules] = useState<WorkoutSchedule[]>([]);
+  const [loadingSchedules, setLoadingSchedules] = useState(false);
+
+  // ── create form ──────────────────────────────────────────────────────
+  const [selectedWorkoutId, setSelectedWorkoutId] = useState('');
+  const [selectedDays, setSelectedDays] = useState<number[]>([]);
+  const [creating, setCreating] = useState(false);
+
+  // ── sync ─────────────────────────────────────────────────────────────
+  const [syncing, setSyncing] = useState(false);
+  const [syncingToday, setSyncingToday] = useState(false);
+  const [syncResults, setSyncResults] = useState<SyncSchedulesResult[] | null>(null);
+  const [syncLabel, setSyncLabel] = useState<string>('');
+
+  // ── load data ────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!garminConnected) return;
+    loadLibrary();
+    loadSchedules();
+  }, [garminConnected]);
+
+  const loadLibrary = async () => {
+    setLoadingLibrary(true);
+    setLibraryError(null);
+    try {
+      const data = await workoutsApi.listLibrary();
+      setLibrary(data);
+    } catch (err: any) {
+      const msg = err.response?.data?.detail ?? 'Failed to load Garmin workouts';
+      setLibraryError(msg);
+    } finally {
+      setLoadingLibrary(false);
+    }
+  };
+
+  const loadSchedules = async () => {
+    setLoadingSchedules(true);
+    try {
+      const data = await workoutsApi.listSchedules();
+      setSchedules(data);
+    } catch {
+      // non-critical
+    } finally {
+      setLoadingSchedules(false);
+    }
+  };
+
+  // ── handlers ─────────────────────────────────────────────────────────
+  const handleCreate = async () => {
+    if (!selectedWorkoutId) return toast.error('Please select a workout');
+    if (selectedDays.length === 0) return toast.error('Please select at least one day');
+
+    const workout = library.find((w) => String(w.workoutId) === selectedWorkoutId);
+    if (!workout) return;
+
+    setCreating(true);
+    try {
+      const schedule = await workoutsApi.createSchedule({
+        workout_id: selectedWorkoutId,
+        workout_name: resolveWorkoutName(workout),
+        days_of_week: selectedDays,
+      });
+      setSchedules((prev) => [schedule, ...prev]);
+      setSelectedWorkoutId('');
+      setSelectedDays([]);
+      toast.success(`Schedule created for "${resolveWorkoutName(workout)}"`);
+    } catch (err: any) {
+      toast.error(err.response?.data?.detail ?? 'Failed to create schedule');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    if (!confirm('Delete this workout schedule?')) return;
+    try {
+      await workoutsApi.deleteSchedule(id);
+      setSchedules((prev) => prev.filter((s) => s.id !== id));
+      toast.success('Schedule deleted');
+    } catch (err: any) {
+      toast.error(err.response?.data?.detail ?? 'Failed to delete schedule');
+    }
+  };
+
+  const handleToggle = async (id: number, is_active: boolean) => {
+    try {
+      const updated = await workoutsApi.toggleSchedule(id, is_active);
+      setSchedules((prev) => prev.map((s) => (s.id === id ? updated : s)));
+    } catch (err: any) {
+      toast.error(err.response?.data?.detail ?? 'Failed to update schedule');
+    }
+  };
+
+  const handleSyncMonth = async () => {
+    setSyncing(true);
+    setSyncResults(null);
+    setSyncLabel(`Next ${SYNC_DAYS} days`);
+    try {
+      const response = await workoutsApi.syncMonth({ days: SYNC_DAYS });
+      setSyncResults(response.results);
+      const { applied, succeeded, failed, skipped } = response;
+      if (applied === 0 && skipped === 0) {
+        toast.info(`No scheduled days in the next ${SYNC_DAYS} days — nothing to push`);
+      } else if (applied === 0 && skipped > 0) {
+        toast.info(`All ${skipped} workout${skipped !== 1 ? 's' : ''} already scheduled — nothing new to push`);
+      } else if (failed === 0) {
+        const skipNote = skipped > 0 ? `, ${skipped} already scheduled` : '';
+        toast.success(`Pushed ${succeeded} workout${succeeded !== 1 ? 's' : ''} to Garmin${skipNote}`);
+      } else {
+        toast.warning(`${succeeded} pushed, ${failed} failed${skipped > 0 ? `, ${skipped} already scheduled` : ''}`);
+      }
+    } catch (err: any) {
+      toast.error(err.response?.data?.detail ?? 'Sync failed');
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  const handleSyncToday = async () => {
+    setSyncingToday(true);
+    setSyncResults(null);
+    const now = new Date();
+    setSyncLabel(`Today (${now.toLocaleDateString(undefined, { weekday: 'long', month: 'short', day: 'numeric' })})`);
+    try {
+      const response = await workoutsApi.syncSchedules();
+      setSyncResults(response.results);
+      if (response.applied === 0) {
+        toast.info('No schedules matched today — nothing to push');
+      } else if (response.failed === 0) {
+        toast.success(
+          `Pushed ${response.succeeded} workout${response.succeeded !== 1 ? 's' : ''} to Garmin`,
+        );
+      } else {
+        toast.warning(`${response.succeeded} succeeded, ${response.failed} failed`);
+      }
+    } catch (err: any) {
+      toast.error(err.response?.data?.detail ?? 'Sync failed');
+    } finally {
+      setSyncingToday(false);
+    }
+  };
+
+  // ── render ───────────────────────────────────────────────────────────
+  if (!garminConnected) {
+    return (
+      <div className="max-w-2xl mx-auto py-12 text-center">
+        <div className="text-4xl mb-4">🏋️</div>
+        <h2 className="text-xl font-semibold text-gray-700 mb-2">Garmin not connected</h2>
+        <p className="text-gray-500">
+          Connect your Garmin account in Settings to manage workout schedules.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-8">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Workout Schedules</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Set up recurring weekly schedules and push them to your Garmin calendar.
+          </p>
+        </div>
+        <div className="flex flex-col items-end gap-2 shrink-0">
+          {/* Primary: Sync Month */}
+          <button
+            type="button"
+            onClick={handleSyncMonth}
+            disabled={syncing || syncingToday || schedules.filter((s) => s.is_active).length === 0}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-white text-sm font-medium
+              hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors cursor-pointer"
+          >
+            {syncing ? (
+              <>
+                <span className="animate-spin inline-block w-4 h-4 border-2 border-white border-t-transparent rounded-full" />
+                Syncing…
+              </>
+            ) : (
+              <>
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                    d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                Sync Next 30 Days
+              </>
+            )}
+          </button>
+          {/* Secondary: Sync Today */}
+          <button
+            type="button"
+            onClick={handleSyncToday}
+            disabled={syncing || syncingToday || schedules.filter((s) => s.is_active).length === 0}
+            className="inline-flex items-center gap-1 text-xs text-gray-500 hover:text-primary
+              disabled:opacity-40 disabled:cursor-not-allowed transition-colors cursor-pointer"
+          >
+            {syncingToday ? (
+              <span className="animate-spin inline-block w-3 h-3 border border-gray-400 border-t-transparent rounded-full" />
+            ) : (
+              <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            )}
+            Sync Today only
+          </button>
+        </div>
+      </div>
+
+      {/* Sync results */}
+      {syncResults !== null && (
+        <div className="rounded-lg border border-gray-200 overflow-hidden">
+          <div className="px-4 py-2 bg-gray-50 border-b flex items-center justify-between">
+            <span className="text-sm font-medium text-gray-700">
+              Results — {syncLabel}
+            </span>
+            <button
+              type="button"
+              onClick={() => setSyncResults(null)}
+              className="text-xs text-gray-400 hover:text-gray-600 cursor-pointer"
+            >
+              Dismiss
+            </button>
+          </div>
+          {syncResults.length === 0 ? (
+            <p className="px-4 py-3 text-sm text-gray-500">No matching scheduled days in this period.</p>
+          ) : (() => {
+            // Group results by date
+            const byDate = syncResults.reduce<Record<string, SyncSchedulesResult[]>>((acc, r) => {
+              (acc[r.date] = acc[r.date] ?? []).push(r);
+              return acc;
+            }, {});
+            return (
+              <ul className="divide-y">
+                {Object.entries(byDate).map(([d, rows]) => (
+                  <li key={d}>
+                    <div className="px-4 py-1.5 bg-gray-50/60 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                      {new Date(d + 'T00:00:00').toLocaleDateString(undefined, {
+                        weekday: 'short', month: 'short', day: 'numeric',
+                      })}
+                    </div>
+                    <ul>
+                      {rows.map((r, i) => (
+                        <li key={i} className="flex items-center gap-3 px-4 py-2 text-sm border-t border-gray-100 first:border-0">
+                          <span className={`w-2 h-2 rounded-full shrink-0 ${
+                            r.skipped ? 'bg-gray-300' : r.success ? 'bg-green-500' : 'bg-red-500'
+                          }`} />
+                          <span className={`flex-1 ${r.skipped ? 'text-gray-400' : 'text-gray-700'}`}>
+                            {r.workout_name}
+                          </span>
+                          {r.skipped && <span className="text-gray-400 text-xs">already scheduled</span>}
+                          {r.error && <span className="text-red-500 text-xs">{r.error}</span>}
+                        </li>
+                      ))}
+                    </ul>
+                  </li>
+                ))}
+              </ul>
+            );
+          })()}
+        </div>
+      )}
+
+      {/* ── Create schedule card ── */}
+      <div className="bg-white rounded-xl border border-gray-200 p-6 space-y-5">
+        <h2 className="text-lg font-semibold text-gray-800">Add Schedule</h2>
+
+        {/* Workout picker */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Workout
+          </label>
+          {loadingLibrary ? (
+            <div className="flex items-center gap-2 text-sm text-gray-500">
+              <span className="animate-spin inline-block w-4 h-4 border-2 border-primary border-t-transparent rounded-full" />
+              Loading your Garmin workouts…
+            </div>
+          ) : libraryError ? (
+            <div className="rounded-md bg-red-50 border border-red-200 px-4 py-3 space-y-2">
+              <p className="text-sm text-red-700">{libraryError}</p>
+              <div className="flex gap-3">
+                <button
+                  type="button"
+                  onClick={() => navigate('/settings')}
+                  className="text-sm font-medium text-white bg-primary hover:bg-primary/90 px-3 py-1 rounded cursor-pointer"
+                >
+                  Re-authenticate Garmin
+                </button>
+                <button
+                  type="button"
+                  onClick={loadLibrary}
+                  className="text-sm text-gray-600 hover:text-gray-900 underline cursor-pointer"
+                >
+                  Retry
+                </button>
+              </div>
+            </div>
+          ) : library.length === 0 ? (
+            <p className="text-sm text-gray-500">
+              No saved workouts found in your Garmin account.
+            </p>
+          ) : (
+            <select
+              value={selectedWorkoutId}
+              onChange={(e) => setSelectedWorkoutId(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm
+                focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+            >
+              <option value="">— Select a workout —</option>
+              {library.map((w) => (
+                <option key={String(w.workoutId)} value={String(w.workoutId)}>
+                  {resolveWorkoutName(w)}
+                  {w.sportType?.sportTypeKey ? ` · ${w.sportType.sportTypeKey}` : ''}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+
+        {/* Day picker */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Repeat on
+          </label>
+          <DayPicker selected={selectedDays} onChange={setSelectedDays} />
+          {selectedDays.length > 0 && (
+            <p className="mt-1 text-xs text-gray-500">
+              Every{' '}
+              {selectedDays
+                .map((d) => DAY_LABELS[d])
+                .join(', ')}
+            </p>
+          )}
+        </div>
+
+        <button
+          type="button"
+          onClick={handleCreate}
+          disabled={creating || !selectedWorkoutId || selectedDays.length === 0}
+          className="w-full py-2 px-4 bg-primary text-white rounded-lg text-sm font-medium
+            hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors cursor-pointer"
+        >
+          {creating ? 'Saving…' : 'Add Schedule'}
+        </button>
+      </div>
+
+      {/* ── Existing schedules ── */}
+      <div>
+        <h2 className="text-lg font-semibold text-gray-800 mb-3">Your Schedules</h2>
+        {loadingSchedules ? (
+          <div className="flex items-center gap-2 text-sm text-gray-500 py-4">
+            <span className="animate-spin inline-block w-4 h-4 border-2 border-primary border-t-transparent rounded-full" />
+            Loading…
+          </div>
+        ) : schedules.length === 0 ? (
+          <div className="text-center py-10 text-gray-400 border border-dashed border-gray-200 rounded-xl">
+            <div className="text-3xl mb-2">📅</div>
+            <p className="text-sm">No workout schedules yet.</p>
+            <p className="text-xs mt-1">Add one above to get started.</p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {schedules.map((s) => (
+              <ScheduleRow
+                key={s.id}
+                schedule={s}
+                onDelete={handleDelete}
+                onToggle={handleToggle}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -9,6 +9,10 @@ export interface AuthStatus {
   username: string | null;
   first_name: string | null;
   last_name: string | null;
+  /** IANA timezone for displaying dates. Default UTC when omitted. */
+  display_timezone?: string;
+  /** Time format: '12h' or '24h'. Default 12h when omitted. */
+  display_time_format?: string;
   strava_connected: boolean;
   garmin_connected: boolean;
   withings_connected?: boolean;
@@ -23,6 +27,29 @@ export interface ProfileUpdate {
   username?: string | null;
   first_name?: string | null;
   last_name?: string | null;
+  display_timezone?: string | null;
+  display_time_format?: string | null; // "12h" | "24h"
+}
+
+/** Sync schedule choices (minutes). Default 5. */
+export const SYNC_SCHEDULE_OPTIONS = [
+  { value: 5, label: '5 min' },
+  { value: 10, label: '10 min' },
+  { value: 15, label: '15 min' },
+  { value: 30, label: '30 min' },
+  { value: 45, label: '45 min' },
+  { value: 60, label: '1h' },
+  { value: 120, label: '2h' },
+  { value: 240, label: '4h' },
+] as const;
+
+/** FIT device settings (user-level). Written into FIT files on export. */
+export interface FitDeviceSettings {
+  device_name?: string | null;
+  serial_number?: string | null;
+  manufacturer_id?: string | null;
+  software_version?: string | null;
+  product_id?: string | null;
 }
 
 /** User settings (GET /auth/settings) */
@@ -30,12 +57,18 @@ export interface UserSettings {
   garmin_to_strava_sync_disabled: boolean;
   garmin_to_strava_sync_disabled_override: boolean | null;
   allow_export_without_gps: boolean;
+  /** Sync schedule interval in minutes. Default 5. */
+  sync_schedule_minutes: number;
+  /** FIT device settings for exported files. */
+  fit_device_settings?: FitDeviceSettings | null;
 }
 
 /** Update user settings (PATCH /auth/settings) */
 export interface SettingsUpdate {
   garmin_to_strava_sync_disabled?: boolean | null;
   allow_export_without_gps?: boolean | null;
+  sync_schedule_minutes?: number | null;
+  fit_device_settings?: FitDeviceSettings | null;
 }
 
 export interface StravaAuthResponse {

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -6,10 +6,36 @@ export interface User {
 
 export interface AuthStatus {
   email: string;
+  username: string | null;
+  first_name: string | null;
+  last_name: string | null;
   strava_connected: boolean;
   garmin_connected: boolean;
   withings_connected?: boolean;
   strava_athlete_id: string | null;
+  /** When true, Garmin → Strava sync is off (only Strava → Garmin runs). */
+  garmin_to_strava_sync_disabled?: boolean;
+}
+
+/** Update profile (PATCH /auth/profile) */
+export interface ProfileUpdate {
+  email?: string | null;
+  username?: string | null;
+  first_name?: string | null;
+  last_name?: string | null;
+}
+
+/** User settings (GET /auth/settings) */
+export interface UserSettings {
+  garmin_to_strava_sync_disabled: boolean;
+  garmin_to_strava_sync_disabled_override: boolean | null;
+  allow_export_without_gps: boolean;
+}
+
+/** Update user settings (PATCH /auth/settings) */
+export interface SettingsUpdate {
+  garmin_to_strava_sync_disabled?: boolean | null;
+  allow_export_without_gps?: boolean | null;
 }
 
 export interface StravaAuthResponse {
@@ -36,4 +62,11 @@ export interface StravaAuthUrlResponse {
 export interface GarminCredentials {
   email: string;
   password: string;
+}
+
+/** Response from POST /auth/garmin/credentials; may require MFA step */
+export interface GarminCredentialsResponse {
+  message: string;
+  mfa_required?: boolean;
+  mfa_token?: string;
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './auth';
 export * from './filter';
 export * from './sync';
+export * from './workout';

--- a/frontend/src/types/sync.ts
+++ b/frontend/src/types/sync.ts
@@ -44,8 +44,11 @@ export interface SyncLogDetails {
   error_message: string | null;
   activity_name: string | null;
   activity_type: string | null;
+  uploaded_file_extension: string | null;
+  uploaded_file_path: string | null;
+  file_available: boolean;
   strava_data: unknown | null;
-  gpx_data: string | null;
+  garmin_data: string | null;
   created_at: string;
   completed_at: string | null;
 }

--- a/frontend/src/types/sync.ts
+++ b/frontend/src/types/sync.ts
@@ -31,3 +31,28 @@ export interface ManualSyncResponse {
   message: string;
   garmin_activity_id?: string;
 }
+
+/** Sync log with debug data (details endpoint). */
+export interface SyncLogDetails {
+  id: number;
+  sync_direction: string;
+  source_activity_id: string;
+  target_activity_id: string | null;
+  strava_activity_id: string;
+  garmin_activity_id: string | null;
+  status: string;
+  error_message: string | null;
+  activity_name: string | null;
+  activity_type: string | null;
+  strava_data: unknown | null;
+  gpx_data: string | null;
+  created_at: string;
+  completed_at: string | null;
+}
+
+/** Filters for bulk delete sync logs. */
+export interface BulkDeleteSyncLogsParams {
+  status?: 'success' | 'failed' | 'skipped' | 'pending';
+  before_date?: string;
+  strava_activity_id?: string;
+}

--- a/frontend/src/types/workout.ts
+++ b/frontend/src/types/workout.ts
@@ -1,0 +1,63 @@
+export interface GarminWorkout {
+  workoutId: string | number;
+  /** Garmin may expose the name as `workoutName` or `name` depending on API version */
+  workoutName?: string;
+  name?: string;
+  sportType?: { sportTypeKey?: string; sportTypeId?: number };
+  /** Resolved display name */
+  displayName?: string;
+}
+
+export interface WorkoutSchedule {
+  id: number;
+  workout_id: string;
+  workout_name: string;
+  /** 0=Mon … 6=Sun */
+  days_of_week: number[];
+  is_active: boolean;
+  created_at: string;
+}
+
+export interface CreateScheduleRequest {
+  workout_id: string;
+  workout_name: string;
+  days_of_week: number[];
+}
+
+export interface SyncSchedulesRequest {
+  date?: string; // YYYY-MM-DD; omit for today
+}
+
+export interface SyncMonthRequest {
+  days?: number; // number of days from today, default 30
+}
+
+export interface SyncSchedulesResult {
+  date: string;       // YYYY-MM-DD — which day this was scheduled on
+  schedule_id: number;
+  workout_name: string;
+  success: boolean;
+  skipped?: boolean;  // true when already scheduled — not an error
+  reason?: string;
+  result?: Record<string, unknown>;
+  error?: string;
+}
+
+export interface SyncSchedulesResponse {
+  date: string;
+  applied: number;
+  succeeded: number;
+  failed: number;
+  results: SyncSchedulesResult[];
+}
+
+export interface SyncMonthResponse {
+  start: string;   // today (YYYY-MM-DD)
+  end: string;     // today + days - 1
+  days: number;
+  applied: number;
+  skipped: number;
+  succeeded: number;
+  failed: number;
+  results: SyncSchedulesResult[];
+}


### PR DESCRIPTION
# Settings, GPS handling, and Sync History UX

## Features

- **New Profile Page** — New page at /profile to edit email, first name, last name, and username. Nav has a Profile link (dropdown and mobile). Backend User model and migration add `username`, `first_name`, `last_name` (username unique).
- **New Settings Page** — New page at /settings with:
  - **Disable Garmin → Strava sync** — When checked, no Garmin→Strava sync runs (manual or automatic).
  - **Enable export without GPS** — When enabled, no-GPS activities can sync in both directions (Strava→Garmin summary-only; Garmin→Strava attempt upload). When disabled, no-GPS activities are skipped with a clear message.
- **Garmin 2FA support** — Users with two-factor authentication on Garmin can connect: enter email/password, then enter the MFA code when prompted. Backend and frontend support the MFA step; packages updated for compatibility.
- **No-GPS handling** — When an activity has no GPS we skip with a clear message (not raw API errors). For Garmin→Strava, if Strava rejects the upload with a no-GPS error we also return skipped with that same message.
- **Sync History UX** — Details, Delete, Retry, and sync buttons show pointer cursor and use `type="button"`. Sync log details and bulk-delete are properly typed in the frontend.

---

## Backend

- **CORS** — Added `PATCH` to `allow_methods` so settings and profile endpoints work from the frontend.
- **Profile** — `GET /auth/status` returns `username`, `first_name`, `last_name`. New `PATCH /auth/profile` to update email, username, first_name, last_name (username unique; validation on update).
- **Garmin 2FA (MFA)** — Credentials endpoint returns `mfa_required` and `mfa_token` when the account has 2FA; new `POST /auth/garmin/mfa` to submit the code. Garmin service uses `start_login_with_mfa` / `complete_mfa` with in-memory pending state; packages (e.g. garminconnect) updated to support `return_on_mfa`.
- **fit_utils** — New module with `NO_GPS_MESSAGE` and `fit_file_has_gps()` to detect GPS in FIT files. Used by Garmin→Strava before upload.
- **Strava→Garmin** — After fetching activity streams, checks for GPS (latlng). If no GPS and "Enable export without GPS" is off, skips with a friendly message. If on, syncs as summary-only to Garmin.
- **Garmin→Strava** — Before uploading to Strava, checks FIT for GPS. If no GPS and "Enable export without GPS" is off, skips with the friendly message. If on, attempts upload. When Strava returns a no-GPS error, returns skipped with the same message.
- **Poll task** — Respects "Disable Garmin→Strava sync"; skips users when that setting is on.
- **Manual Garmin→Strava route** — Returns 403 when "Disable Garmin→Strava sync" is on.

---

## Frontend

- **Profile page** — Form to edit email, username, first name, last name; saves via `PATCH /auth/profile`. Layout dropdown and mobile nav link to /profile.
- **Auth (Garmin 2FA)** — When Garmin credentials return `mfa_required`, Auth page shows MFA code step; user submits code via `POST /auth/garmin/mfa`. Auth API and useAuth expose `submitGarminMfa`.
- **Types** — Added `SyncLogDetails` and `BulkDeleteSyncLogsParams`. Sync History details modal and bulk-delete use these instead of `any`.
- **Sync History** — All action buttons (Details, Retry, Delete, Bulk Delete, modal close) use `type="button"` and `cursor-pointer`.
- **Dashboard & Activities list** — Sync and "Sync Activity" buttons use `cursor-pointer`.
- **Settings** — Description for "Enable export without GPS" updated to say it applies to both Strava→Garmin and Garmin→Strava.

---

## Files modified

| File | Change |
|------|--------|
| `backend/app/main.py` | Add PATCH to CORS `allow_methods`. |
| `backend/app/routes/auth.py` | Garmin MFA (mfa_required, POST /garmin/mfa); GET /auth/status returns username, first_name, last_name; new PATCH /auth/profile. |
| `backend/app/models/user.py` | Add username (unique), first_name, last_name. |
| `backend/migrations/versions/a5b6c7d8e9f0_*.py` | Add users.username, first_name, last_name; unique index on username. |
| `backend/app/services/garmin_service.py` | start_login_with_mfa, complete_mfa; MFA pending state; return_on_mfa support. |
| `backend/requirements.txt` | Updated garminconnect (or deps) for 2FA support. |
| `backend/app/utils/fit_utils.py` | **New.** `fit_file_has_gps()`, `NO_GPS_MESSAGE`. |
| `backend/app/services/garmin_to_strava_sync_service.py` | Pre-upload GPS check using "Enable export without GPS"; map Strava no-GPS errors to skipped + message. |
| `backend/app/tasks/sync_tasks.py` | Skip user in poll when Garmin→Strava sync is disabled. |
| `backend/app/utils/user_settings.py` | `get_garmin_to_strava_sync_enabled`, `get_allow_export_without_gps` (if not already present). |
| `frontend/src/pages/ProfilePage.tsx` | **New.** Form for email, username, first name, last name; PATCH /auth/profile. |
| `frontend/src/components/layout/Layout.tsx` | Profile link in dropdown and mobile nav. |
| `frontend/src/App.tsx` | Route /profile → ProfilePage. |
| `frontend/src/pages/AuthPage.tsx` | Garmin MFA step: show code input when mfa_required; submit via submitGarminMfa. |
| `frontend/src/api/auth.ts` | updateProfile (PATCH /auth/profile); submitGarminMfa (POST /auth/garmin/mfa); types for mfa_required, mfa_token, profile. |
| `frontend/src/hooks/useAuth.ts` | submitGarminMfa, isSubmittingGarminMfa. |
| `frontend/src/types/auth.ts` | AuthStatus: username, first_name, last_name; ProfileUpdate; Garmin credentials: mfa_required, mfa_token. |
| `frontend/src/types/sync.ts` | Add `SyncLogDetails`, `BulkDeleteSyncLogsParams`. |
| `frontend/src/api/sync.ts` | Use new types for `getSyncLogDetails`, `bulkDeleteSyncLogs`. |
| `frontend/src/pages/SyncHistoryPage.tsx` | Typed state/handlers; `type="button"` and `cursor-pointer` on buttons. |
| `frontend/src/pages/SettingsPage.tsx` | Copy for "Enable export without GPS" says both directions. |
| `frontend/src/components/ActivitiesList.tsx` | `cursor-pointer` on Sync button. |
| `frontend/src/pages/DashboardPage.tsx` | `cursor-pointer` on Sync Activity buttons. |

---

## Testing

- Backend: Settings and profile PATCH work; Garmin 2FA flow (credentials → mfa_required, then POST /garmin/mfa); Garmin→Strava respects disabled setting and "Enable export without GPS"; no-GPS shows friendly message.
- Frontend: Profile edit (email, username, first name, last name); Garmin connect with 2FA (enter code when prompted); Settings save; Sync History details and bulk delete; buttons show pointer and don’t submit forms. `npm run build` and `npm test` pass.
