### PR TITLE
feat: add disconnect actions for Garmin and Withings

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -184,6 +184,15 @@ async def verify_garmin_mfa(
     return {"message": "Garmin MFA verified successfully", "requires_mfa": False}
 
 
+@router.delete("/garmin")
+async def disconnect_garmin(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    GarminService(db).disconnect(current_user)
+    return {"message": "Garmin disconnected successfully"}
+
+
 @router.get("/withings/auth-url")
 async def get_withings_auth_url():
     try:
@@ -217,6 +226,15 @@ async def exchange_withings_code(
     except Exception as e:
         logger.error(f"Error exchanging Withings code: {e}", exc_info=True)
         raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.delete("/withings")
+async def disconnect_withings(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    WithingsService(db).disconnect(current_user)
+    return {"message": "Withings disconnected successfully"}
 
 
 @router.get("/status")

--- a/backend/app/services/garmin_service.py
+++ b/backend/app/services/garmin_service.py
@@ -147,6 +147,15 @@ class GarminService:
         self.db.refresh(garmin_auth)
         return garmin_auth
 
+    def disconnect(self, user: User) -> None:
+        """Delete the stored Garmin auth record for a user, if present."""
+        garmin_auth = self.db.query(GarminAuth).filter(GarminAuth.user_id == user.id).first()
+        if not garmin_auth:
+            return
+
+        self.db.delete(garmin_auth)
+        self.db.commit()
+
     def connect(self, user: User) -> bool:
         """
         Connect to Garmin Connect for a user.

--- a/backend/app/services/withings_service.py
+++ b/backend/app/services/withings_service.py
@@ -133,6 +133,15 @@ class WithingsService:
         self.db.refresh(withings_auth)
         return withings_auth
 
+    def disconnect(self, user: User) -> None:
+        """Delete the stored Withings auth record for a user, if present."""
+        withings_auth = self.db.query(WithingsAuth).filter(WithingsAuth.user_id == user.id).first()
+        if not withings_auth:
+            return
+
+        self.db.delete(withings_auth)
+        self.db.commit()
+
     def _refresh_token(self, withings_auth: WithingsAuth) -> WithingsAuth:
         """
         Refresh expired access token.

--- a/backend/tests/routes/test_auth.py
+++ b/backend/tests/routes/test_auth.py
@@ -1,0 +1,107 @@
+from datetime import datetime, timedelta
+
+from app.main import app
+from app.middleware.auth import get_current_user
+from app.models.auth import GarminAuth, StravaAuth, WithingsAuth
+from app.utils.crypto import encrypt
+
+
+def test_disconnect_garmin_removes_auth_and_updates_status(client, test_db, test_user):
+    test_db.add(
+        StravaAuth(
+            user_id=test_user.id,
+            access_token="strava-access",
+            refresh_token="strava-refresh",
+            expires_at=datetime.utcnow() + timedelta(hours=1),
+            athlete_id="12345",
+        )
+    )
+    test_db.add(
+        GarminAuth(
+            user_id=test_user.id,
+            encrypted_email=encrypt("garmin@example.com"),
+            encrypted_password=encrypt("garmin-password"),
+            session_data="stored-session",
+        )
+    )
+    test_db.commit()
+    test_db.refresh(test_user)
+
+    app.dependency_overrides[get_current_user] = lambda: test_user
+
+    response = client.delete("/api/v1/auth/garmin")
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "Garmin disconnected successfully"}
+    assert test_db.query(GarminAuth).filter(GarminAuth.user_id == test_user.id).first() is None
+
+    status_response = client.get("/api/v1/auth/status")
+    assert status_response.status_code == 200
+    assert status_response.json()["garmin_connected"] is False
+    assert status_response.json()["garmin_requires_mfa"] is False
+
+
+def test_disconnect_garmin_is_idempotent_for_pending_mfa(client, test_db, test_user):
+    test_db.add(
+        GarminAuth(
+            user_id=test_user.id,
+            encrypted_email=encrypt("garmin@example.com"),
+            encrypted_password=encrypt("garmin-password"),
+            encrypted_mfa_token=encrypt("pending-mfa-token"),
+        )
+    )
+    test_db.commit()
+    test_db.refresh(test_user)
+
+    app.dependency_overrides[get_current_user] = lambda: test_user
+
+    first_response = client.delete("/api/v1/auth/garmin")
+    second_response = client.delete("/api/v1/auth/garmin")
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert test_db.query(GarminAuth).filter(GarminAuth.user_id == test_user.id).first() is None
+
+
+def test_disconnect_withings_removes_auth_and_updates_status(client, test_db, test_user):
+    test_db.add(
+        StravaAuth(
+            user_id=test_user.id,
+            access_token="strava-access",
+            refresh_token="strava-refresh",
+            expires_at=datetime.utcnow() + timedelta(hours=1),
+            athlete_id="12345",
+        )
+    )
+    test_db.add(
+        WithingsAuth(
+            user_id=test_user.id,
+            withings_userid="withings-user",
+            access_token="withings-access",
+            refresh_token="withings-refresh",
+            expires_at=datetime.utcnow() + timedelta(hours=1),
+        )
+    )
+    test_db.commit()
+    test_db.refresh(test_user)
+
+    app.dependency_overrides[get_current_user] = lambda: test_user
+
+    response = client.delete("/api/v1/auth/withings")
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "Withings disconnected successfully"}
+    assert test_db.query(WithingsAuth).filter(WithingsAuth.user_id == test_user.id).first() is None
+
+    status_response = client.get("/api/v1/auth/status")
+    assert status_response.status_code == 200
+    assert status_response.json()["withings_connected"] is False
+
+
+def test_disconnect_withings_is_idempotent(client, test_user):
+    app.dependency_overrides[get_current_user] = lambda: test_user
+
+    response = client.delete("/api/v1/auth/withings")
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "Withings disconnected successfully"}

--- a/docs/plans/18-add-option-to-disconnect-garmin-and-withings.md
+++ b/docs/plans/18-add-option-to-disconnect-garmin-and-withings.md
@@ -1,0 +1,205 @@
+# Plan for #18: Add Option to Disconnect Garmin and Withings
+
+Issue: https://github.com/splagemann/strava-garmin-bridge/issues/18
+
+## Goal
+
+Add dashboard controls to disconnect Garmin and Withings after they have been connected.
+
+This issue is downstream of `docs/plans/15-refactor-login.md`, because the requested UI change explicitly says to remove Strava from the dashboard connections section once Strava is the primary login. The implementation for #18 should therefore assume:
+
+- Strava remains the required app login and is not disconnectable from the dashboard.
+- The dashboard connections section only manages optional integrations.
+- Garmin and Withings can be connected and disconnected independently after login.
+
+Today the repo supports:
+
+- Garmin connect via stored encrypted credentials and optional MFA in `backend/app/routes/auth.py` and `backend/app/services/garmin_service.py`.
+- Withings connect via OAuth token exchange in `backend/app/routes/auth.py` and `backend/app/services/withings_service.py`.
+- Dashboard connection status rendering in `frontend/src/pages/DashboardPage.tsx`.
+
+What is missing is a first-class disconnect path in both the backend and frontend.
+
+## Affected Areas
+
+Backend:
+
+- `backend/app/routes/auth.py`
+  - Add authenticated disconnect endpoints for Garmin and Withings.
+  - Keep `/api/v1/auth/status` as the source of truth for connection state after disconnect.
+- `backend/app/services/garmin_service.py`
+  - Add a repo-local method to delete or clear the user’s Garmin auth record.
+- `backend/app/services/withings_service.py`
+  - Add a repo-local method to delete the user’s Withings auth record.
+- `backend/app/models/auth.py`
+  - No schema change is required if disconnect is implemented as deleting existing `GarminAuth` and `WithingsAuth` rows.
+- `backend/app/tasks/sync_tasks.py`
+  - No feature changes required, but disconnect semantics must stay compatible with the existing `if not user.garmin_auth` and `if not user.withings_auth` guards.
+- `backend/app/routes/sync.py`
+  - Existing guards should continue returning clean errors when Garmin has been disconnected.
+- `backend/app/services/weight_sync_service.py`
+  - Existing `withings_auth` and `garmin_auth` dependency checks should naturally stop weight sync once either integration is removed.
+- Tests likely to add:
+  - `backend/tests/routes/` for disconnect endpoints and updated auth status behavior.
+  - Possibly `backend/tests/services/` for service-level deletion helpers if that logic becomes non-trivial.
+
+Frontend:
+
+- `frontend/src/pages/DashboardPage.tsx`
+  - Remove Strava from the connections section once #15 behavior is in place.
+  - Replace the current read-only connected badges for Garmin and Withings with connect/disconnect actions.
+- `frontend/src/hooks/useAuth.ts`
+  - Add disconnect mutations and keep `QUERY_KEYS.authStatus` invalidated after connect and disconnect.
+- `frontend/src/api/auth.ts`
+  - Add authenticated API methods for disconnecting Garmin and Withings.
+- `frontend/src/types/auth.ts`
+  - Existing `AuthStatus` shape is likely sufficient unless the UI needs a new explicit flag.
+- `frontend/src/pages/DashboardPage.test.tsx`
+  - Extend coverage for disconnect actions, the absence of Strava in the connections section, and post-disconnect UI state.
+- Potentially `frontend/src/hooks/useAuth.test.tsx`
+  - Add mutation coverage for the new disconnect methods.
+
+Related context:
+
+- `frontend/src/components/ActivitiesList.tsx`
+  - Already uses `authStatus.garmin_connected` to gate Garmin-specific actions. This behavior should remain correct after disconnect.
+- `frontend/src/pages/WithingsCallbackPage.tsx`
+  - No direct changes expected, but disconnect must not break reconnect after a previous connection existed.
+
+## Proposed Approach
+
+1. Treat disconnect as removal of the integration record, not as a soft-disabled flag.
+   - For Garmin, delete the user’s `GarminAuth` row.
+   - For Withings, delete the user’s `WithingsAuth` row.
+   - This matches the current repo contract, where connection status is derived from whether the related auth record exists and, for Garmin, whether session data exists.
+   - Avoid a schema migration unless implementation uncovers a strong reason to preserve historical inactive auth rows.
+
+2. Add backend disconnect endpoints under the existing auth router.
+   - Add something like `DELETE /api/v1/auth/garmin` and `DELETE /api/v1/auth/withings` in `backend/app/routes/auth.py`.
+   - Protect both with `get_current_user`.
+   - Return a small success payload such as `{ "message": "Garmin disconnected successfully" }`.
+   - Make repeated disconnect calls idempotent from the client’s perspective.
+   - Preferred behavior: return success even when already disconnected, so the UI can safely refresh state without special casing.
+
+3. Encapsulate deletion logic in service methods instead of deleting records inline in the route.
+   - Add `disconnect(user)` or equivalent methods to:
+     - `backend/app/services/garmin_service.py`
+     - `backend/app/services/withings_service.py`
+   - Garmin disconnect should remove all persisted Garmin secrets and session state by deleting the row rather than merely nulling columns.
+   - Withings disconnect should remove stored OAuth access and refresh tokens by deleting the row.
+   - Keep the route layer thin and leave persistence behavior centralized.
+
+4. Keep `auth_status` as the only frontend source of truth after mutation.
+   - No optimistic state rewrite is needed.
+   - After disconnect, the frontend should invalidate and refetch `QUERY_KEYS.authStatus`.
+   - This keeps Garmin MFA edge cases aligned with backend truth and avoids UI drift.
+
+5. Update the dashboard connections UX for the post-#15 world.
+   - Remove the Strava badge from the dashboard connections section once #15 lands.
+   - Garmin:
+     - When disconnected, keep the existing connect form and MFA flow.
+     - When connected, show a disconnect button instead of only a green badge.
+     - If `garmin_requires_mfa` is true and `garmin_connected` is false, treat it as an incomplete connection, not a connected state. Do not show a disconnect button unless the team decides users should be allowed to cancel the pending Garmin setup.
+   - Withings:
+     - When disconnected, keep the existing `Connect Withings` button.
+     - When connected, show a disconnect button next to or instead of the connected badge.
+   - Use confirmation UX before disconnect if the current dashboard style already supports destructive confirmation. If not, a simple browser confirm is an acceptable low-scope first step.
+
+6. Preserve the current downstream behavior after disconnect.
+   - Garmin disconnect should automatically disable:
+     - manual Strava -> Garmin sync
+     - manual Garmin -> Strava sync
+     - Garmin activity fetches
+     - Withings -> Garmin weight sync
+     - background Garmin-related task processing for that user
+   - Withings disconnect should automatically disable Withings weight import while leaving Garmin activity sync untouched.
+   - These behaviors already follow from current guards, so the implementation should lean on those existing checks rather than adding duplicate state.
+
+7. Add repo-specific tests around the new contract.
+   - Backend:
+     - disconnect Garmin when connected
+     - disconnect Garmin when already disconnected
+     - disconnect Withings when connected
+     - disconnect Withings when already disconnected
+     - `GET /api/v1/auth/status` reflects the disconnected state immediately afterward
+   - Frontend:
+     - dashboard renders disconnect controls for connected Garmin/Withings
+     - clicking disconnect calls the right hook/API method
+     - after disconnect, the UI falls back to `Connect Garmin` or `Connect Withings`
+     - Strava no longer appears in the connections section after the #15 assumptions are applied
+
+## Repo-Specific Notes
+
+- Garmin connection state is currently not just `user.garmin_auth is not None`; `backend/app/routes/auth.py` marks Garmin connected only when `session_data` exists.
+- Garmin MFA pending state is tracked separately via `encrypted_mfa_token`.
+- Because of that split, deleting the Garmin auth row is cleaner than nulling selected fields and trying to preserve partial state.
+- Withings connection state is simpler: `current_user.withings_auth is not None`.
+- Existing periodic task guards in `backend/app/tasks/sync_tasks.py` already assume disconnect means the related auth row is absent.
+- Existing frontend gating in `frontend/src/components/ActivitiesList.tsx` already reacts correctly to `authStatus.garmin_connected === false`, so no special disconnect-only path should be needed there.
+
+## Edge Cases
+
+- Disconnect Garmin while a Garmin MFA challenge is pending.
+  - Decide whether the disconnect action should be available in this state.
+  - Recommended: yes, and it should delete the pending `GarminAuth` row so the user can fully reset the setup flow.
+
+- Disconnect Garmin after credentials are saved but before a valid session is restored.
+  - The backend should still treat this as a normal disconnect and remove stored encrypted credentials.
+
+- Disconnect Withings when tokens are expired.
+  - Disconnect should delete local credentials only and should not depend on a successful remote API call.
+
+- Repeated disconnect clicks or a stale UI retry.
+  - Endpoint should be idempotent so the second request still resolves cleanly.
+
+- Disconnect during active background processing.
+  - Already-queued jobs may still start with stale user state, but subsequent guards should fail cleanly once the job reloads the user or attempts to access missing auth.
+  - The implementation does not need a job cancellation system for this issue.
+
+- Disconnect Garmin while Withings remains connected.
+  - Weight sync should stop because `WeightSyncService` already requires both integrations.
+  - The dashboard should make it clear that Withings can stay connected independently even though weight sync is blocked without Garmin.
+
+- Disconnect Withings while Garmin remains connected.
+  - Activity sync continues to work.
+  - Only Withings-specific features should disappear.
+
+- Future interaction with issue #15.
+  - If #15 has not landed yet, the implementation PR for #18 should either stack on top of #15 or explicitly include the minimal UI reshaping needed to remove Strava from the connections section without reintroducing the old login assumptions.
+
+## Validation
+
+Backend automated validation:
+
+- `cd backend && pytest`
+- Focused runs if route tests are added:
+  - `cd backend && pytest tests/routes tests/services`
+
+Frontend automated validation:
+
+- `cd frontend && npm test -- --run`
+- Focused runs:
+  - `cd frontend && npm test -- --run src/pages/DashboardPage.test.tsx src/hooks/useAuth.test.tsx`
+
+Manual validation in this repo’s flow:
+
+1. Log in with Strava and confirm the dashboard connections section does not show Strava anymore once #15 behavior is present.
+2. Connect Garmin and confirm the dashboard shows Garmin as connected with a disconnect action.
+3. Disconnect Garmin and confirm:
+   - the Garmin connection card switches back to the connect form
+   - Garmin sync buttons become unavailable
+   - Garmin activity views and Garmin-specific dashboard actions stop working cleanly
+   - `GET /api/v1/auth/status` returns `garmin_connected: false`
+4. Connect Withings and confirm the dashboard shows Withings as connected with a disconnect action.
+5. Disconnect Withings and confirm:
+   - the dashboard switches back to `Connect Withings`
+   - `GET /api/v1/auth/status` returns `withings_connected: false`
+   - Garmin activity sync remains unaffected if Garmin is still connected
+6. If Garmin MFA is required, start Garmin setup, then disconnect, and confirm the next Garmin connect attempt starts from a clean state.
+
+## Out of Scope
+
+- Disconnecting Strava from inside the authenticated dashboard.
+- Changing the login architecture beyond the dependency on #15.
+- Revoking Garmin or Withings tokens/sessions with the upstream provider if those APIs are not already integrated here.
+- Adding new database columns or migrations unless implementation reveals a real persistence requirement that cannot be met by deleting auth rows.

--- a/frontend/src/api/auth.test.ts
+++ b/frontend/src/api/auth.test.ts
@@ -10,6 +10,7 @@ vi.mock('./client', async () => {
     apiClient: {
       get: vi.fn(),
       post: vi.fn(),
+      delete: vi.fn(),
     },
   };
 });
@@ -143,6 +144,28 @@ describe('authApi', () => {
         state: 'state',
         signed_state: 'signed'
       });
+      expect(result).toEqual(mockResponse.data);
+    });
+  });
+
+  describe('disconnects', () => {
+    it('should disconnect Garmin', async () => {
+      const mockResponse = { data: { message: 'Garmin disconnected successfully' } };
+      (apiClient.delete as any).mockResolvedValue(mockResponse);
+
+      const result = await authApi.disconnectGarmin();
+
+      expect(apiClient.delete).toHaveBeenCalledWith('/api/v1/auth/garmin');
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should disconnect Withings', async () => {
+      const mockResponse = { data: { message: 'Withings disconnected successfully' } };
+      (apiClient.delete as any).mockResolvedValue(mockResponse);
+
+      const result = await authApi.disconnectWithings();
+
+      expect(apiClient.delete).toHaveBeenCalledWith('/api/v1/auth/withings');
       expect(result).toEqual(mockResponse.data);
     });
   });

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -85,6 +85,16 @@ export const authApi = {
     return response.data;
   },
 
+  disconnectGarmin: async (): Promise<{ message: string }> => {
+    const response = await apiClient.delete<{ message: string }>('/api/v1/auth/garmin');
+    return response.data;
+  },
+
+  disconnectWithings: async (): Promise<{ message: string }> => {
+    const response = await apiClient.delete<{ message: string }>('/api/v1/auth/withings');
+    return response.data;
+  },
+
   getAuthStatus: async (): Promise<AuthStatus> => {
     const response = await apiClient.get<AuthStatus>('/api/v1/auth/status');
     return response.data;

--- a/frontend/src/hooks/useAuth.test.tsx
+++ b/frontend/src/hooks/useAuth.test.tsx
@@ -12,6 +12,8 @@ vi.mock('../api', () => ({
     getAuthStatus: vi.fn(),
     saveGarminCredentials: vi.fn(),
     verifyGarminMfa: vi.fn(),
+    disconnectGarmin: vi.fn(),
+    disconnectWithings: vi.fn(),
     connectStrava: vi.fn(),
     connectWithings: vi.fn(),
     logout: vi.fn(),
@@ -101,6 +103,24 @@ describe('useAuth', () => {
 
     result.current.logout();
     expect(authApi.logout).toHaveBeenCalled();
+  });
+
+  it('disconnectGarmin calls mutation', async () => {
+    (clientApi.isAuthenticated as any).mockReturnValue(true);
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await result.current.disconnectGarmin();
+
+    expect(authApi.disconnectGarmin).toHaveBeenCalled();
+  });
+
+  it('disconnectWithings calls mutation', async () => {
+    (clientApi.isAuthenticated as any).mockReturnValue(true);
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await result.current.disconnectWithings();
+
+    expect(authApi.disconnectWithings).toHaveBeenCalled();
   });
 
   it('saveGarminCredentials calls mutation', async () => {

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -29,6 +29,20 @@ export function useAuth() {
     },
   });
 
+  const disconnectGarminMutation = useMutation({
+    mutationFn: authApi.disconnectGarmin,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.authStatus });
+    },
+  });
+
+  const disconnectWithingsMutation = useMutation({
+    mutationFn: authApi.disconnectWithings,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.authStatus });
+    },
+  });
+
   const connectStrava = async () => {
     try {
       await authApi.connectStrava();
@@ -55,6 +69,14 @@ export function useAuth() {
     return verifyGarminMfaMutation.mutateAsync({ code });
   };
 
+  const disconnectGarmin = async () => {
+    return disconnectGarminMutation.mutateAsync();
+  };
+
+  const disconnectWithings = async () => {
+    return disconnectWithingsMutation.mutateAsync();
+  };
+
   const logout = () => {
     authApi.logout();
   };
@@ -69,9 +91,13 @@ export function useAuth() {
     connectWithings,
     saveGarminCredentials,
     verifyGarminMfa,
+    disconnectGarmin,
+    disconnectWithings,
     logout,
     isSavingGarmin: saveGarminMutation.isPending,
     isVerifyingGarminMfa: verifyGarminMfaMutation.isPending,
+    isDisconnectingGarmin: disconnectGarminMutation.isPending,
+    isDisconnectingWithings: disconnectWithingsMutation.isPending,
     garminError: saveGarminMutation.error ?? verifyGarminMfaMutation.error,
   };
 }

--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -49,6 +49,8 @@ describe('DashboardPage', () => {
   const mockConnectWithings = vi.fn();
   const mockSaveGarminCredentials = vi.fn();
   const mockVerifyGarminMfa = vi.fn();
+  const mockDisconnectGarmin = vi.fn();
+  const mockDisconnectWithings = vi.fn();
   const mockManualSync = vi.fn();
   const mockRefetch = vi.fn();
 
@@ -59,8 +61,12 @@ describe('DashboardPage', () => {
       connectWithings: mockConnectWithings,
       saveGarminCredentials: mockSaveGarminCredentials,
       verifyGarminMfa: mockVerifyGarminMfa,
+      disconnectGarmin: mockDisconnectGarmin,
+      disconnectWithings: mockDisconnectWithings,
       isSavingGarmin: false,
       isVerifyingGarminMfa: false,
+      isDisconnectingGarmin: false,
+      isDisconnectingWithings: false,
     });
     (useSync as any).mockReturnValue({
       syncStats: mockSyncStats,
@@ -79,8 +85,8 @@ describe('DashboardPage', () => {
 
   it('renders connections status', () => {
     render(<DashboardPage />);
-    expect(screen.getByText('Strava')).toBeInTheDocument();
-    expect(screen.getByText('Garmin')).toBeInTheDocument();
+    expect(screen.queryByText('Strava')).not.toBeInTheDocument();
+    expect(screen.getByText('Garmin Connected')).toBeInTheDocument();
     expect(screen.getByText('Connect Withings')).toBeInTheDocument();
   });
 
@@ -90,8 +96,12 @@ describe('DashboardPage', () => {
       connectWithings: mockConnectWithings,
       saveGarminCredentials: mockSaveGarminCredentials,
       verifyGarminMfa: mockVerifyGarminMfa,
+      disconnectGarmin: mockDisconnectGarmin,
+      disconnectWithings: mockDisconnectWithings,
       isSavingGarmin: false,
       isVerifyingGarminMfa: false,
+      isDisconnectingGarmin: false,
+      isDisconnectingWithings: false,
     });
 
     render(<DashboardPage />);
@@ -134,6 +144,66 @@ describe('DashboardPage', () => {
     
     await waitFor(() => {
       expect(mockConnectWithings).toHaveBeenCalled();
+    });
+  });
+
+  it('handles Garmin disconnect when connected', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<DashboardPage />);
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }));
+
+    await waitFor(() => {
+      expect(mockDisconnectGarmin).toHaveBeenCalled();
+    });
+  });
+
+  it('handles Garmin disconnect during MFA pending state', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    (useAuth as any).mockReturnValue({
+      authStatus: { garmin_connected: false, garmin_requires_mfa: true, withings_connected: false },
+      connectWithings: mockConnectWithings,
+      saveGarminCredentials: mockSaveGarminCredentials,
+      verifyGarminMfa: mockVerifyGarminMfa,
+      disconnectGarmin: mockDisconnectGarmin,
+      disconnectWithings: mockDisconnectWithings,
+      isSavingGarmin: false,
+      isVerifyingGarminMfa: false,
+      isDisconnectingGarmin: false,
+      isDisconnectingWithings: false,
+    });
+
+    render(<DashboardPage />);
+
+    expect(screen.getByText('Garmin MFA Pending')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }));
+
+    await waitFor(() => {
+      expect(mockDisconnectGarmin).toHaveBeenCalled();
+    });
+  });
+
+  it('handles Withings disconnect when connected', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    (useAuth as any).mockReturnValue({
+      authStatus: { garmin_connected: true, withings_connected: true },
+      connectWithings: mockConnectWithings,
+      saveGarminCredentials: mockSaveGarminCredentials,
+      verifyGarminMfa: mockVerifyGarminMfa,
+      disconnectGarmin: mockDisconnectGarmin,
+      disconnectWithings: mockDisconnectWithings,
+      isSavingGarmin: false,
+      isVerifyingGarminMfa: false,
+      isDisconnectingGarmin: false,
+      isDisconnectingWithings: false,
+    });
+
+    render(<DashboardPage />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Disconnect' })[1]);
+
+    await waitFor(() => {
+      expect(mockDisconnectWithings).toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -15,8 +15,12 @@ export default function DashboardPage() {
     connectWithings,
     saveGarminCredentials,
     verifyGarminMfa,
+    disconnectGarmin,
+    disconnectWithings,
     isSavingGarmin,
     isVerifyingGarminMfa,
+    isDisconnectingGarmin,
+    isDisconnectingWithings,
   } = useAuth();
   const { syncStats, syncHistory, manualSync, isSyncing, refetch } = useSync();
   const [activeTab, setActiveTab] = useState<SyncDirection>('strava_to_garmin');
@@ -29,6 +33,8 @@ export default function DashboardPage() {
   const [requiresGarminMfa, setRequiresGarminMfa] = useState(false);
 
   const garminConnected = !!authStatus?.garmin_connected;
+  const garminNeedsAttention = !!authStatus?.garmin_requires_mfa;
+  const canDisconnectGarmin = garminConnected || garminNeedsAttention;
 
   useEffect(() => {
     if (!garminConnected && activeTab === 'garmin_to_strava') {
@@ -78,6 +84,39 @@ export default function DashboardPage() {
       toast.success('Garmin MFA verified successfully!');
     } catch (error: any) {
       toast.error(error.response?.data?.detail || 'Failed to verify Garmin MFA code');
+    }
+  };
+
+  const handleGarminDisconnect = async () => {
+    if (!window.confirm('Disconnect Garmin? This will remove stored Garmin credentials and any pending MFA state.')) {
+      return;
+    }
+
+    try {
+      await disconnectGarmin();
+      setGarminEmail('');
+      setGarminPassword('');
+      setGarminMfaCode('');
+      setRequiresGarminMfa(false);
+      if (activeTab === 'garmin_to_strava') {
+        setActiveTab('strava_to_garmin');
+      }
+      toast.success('Garmin disconnected successfully.');
+    } catch (error: any) {
+      toast.error(error.response?.data?.detail || 'Failed to disconnect Garmin');
+    }
+  };
+
+  const handleWithingsDisconnect = async () => {
+    if (!window.confirm('Disconnect Withings? This will remove stored Withings access for this app.')) {
+      return;
+    }
+
+    try {
+      await disconnectWithings();
+      toast.success('Withings disconnected successfully.');
+    } catch (error: any) {
+      toast.error(error.response?.data?.detail || 'Failed to disconnect Withings');
     }
   };
 
@@ -133,18 +172,8 @@ export default function DashboardPage() {
       <div className="bg-white rounded-lg shadow p-4 sm:p-6">
         <h2 className="text-lg font-semibold mb-4">Connections</h2>
         <div className="flex flex-wrap gap-4 mb-6">
-          <div className="flex items-center gap-2 px-3 py-2 bg-green-50 text-green-700 rounded-md border border-green-200">
-            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-              <path
-                fillRule="evenodd"
-                d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                clipRule="evenodd"
-              />
-            </svg>
-            <span className="font-medium">Strava</span>
-          </div>
-          {garminConnected ? (
-            <div className="flex items-center gap-2 px-3 py-2 bg-green-50 text-green-700 rounded-md border border-green-200">
+          {canDisconnectGarmin ? (
+            <div className="flex items-center gap-3 px-3 py-2 rounded-md border border-green-200 bg-green-50 text-green-700">
               <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
                 <path
                   fillRule="evenodd"
@@ -152,7 +181,15 @@ export default function DashboardPage() {
                   clipRule="evenodd"
                 />
               </svg>
-              <span className="font-medium">Garmin</span>
+              <span className="font-medium">{garminConnected ? 'Garmin Connected' : 'Garmin MFA Pending'}</span>
+              <button
+                type="button"
+                onClick={handleGarminDisconnect}
+                disabled={isDisconnectingGarmin}
+                className="text-sm font-medium text-red-700 hover:text-red-800 disabled:opacity-50"
+              >
+                {isDisconnectingGarmin ? 'Disconnecting...' : 'Disconnect'}
+              </button>
             </div>
           ) : (
             <div className="flex items-center gap-2 px-3 py-2 bg-amber-50 text-amber-700 rounded-md border border-amber-200">
@@ -164,7 +201,7 @@ export default function DashboardPage() {
           )}
 
           {authStatus?.withings_connected ? (
-            <div className="flex items-center gap-2 px-3 py-2 bg-green-50 text-green-700 rounded-md border border-green-200">
+            <div className="flex items-center gap-3 px-3 py-2 bg-green-50 text-green-700 rounded-md border border-green-200">
               <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
                 <path
                   fillRule="evenodd"
@@ -172,7 +209,15 @@ export default function DashboardPage() {
                   clipRule="evenodd"
                 />
               </svg>
-              <span className="font-medium">Withings</span>
+              <span className="font-medium">Withings Connected</span>
+              <button
+                type="button"
+                onClick={handleWithingsDisconnect}
+                disabled={isDisconnectingWithings}
+                className="text-sm font-medium text-red-700 hover:text-red-800 disabled:opacity-50"
+              >
+                {isDisconnectingWithings ? 'Disconnecting...' : 'Disconnect'}
+              </button>
             </div>
           ) : (
             <button


### PR DESCRIPTION
## Summary
- add authenticated disconnect endpoints for Garmin and Withings
- wire dashboard disconnect actions through the auth API/hook and remove Strava from the Connections section
- cover the new disconnect flows with focused frontend tests plus backend route coverage

Closes #18

## Verification
- 
- 
> frontend@0.0.0 test
> vitest --run src/api/auth.test.ts src/hooks/useAuth.test.tsx src/pages/DashboardPage.test.tsx


 RUN  v2.1.9 /Users/sebastian/Development/strava-garmin-bridge/frontend

 ✓ src/api/auth.test.ts (9 tests) 4ms
 ✓ src/hooks/useAuth.test.tsx (9 tests) 123ms
 ✓ src/pages/DashboardPage.test.tsx (11 tests) 171ms

 Test Files  3 passed (3)
      Tests  29 passed (29)
   Start at  00:16:58
   Duration  878ms (transform 100ms, setup 186ms, collect 241ms, tests 298ms, environment 573ms, prepare 99ms)